### PR TITLE
feat: datasource - blockstorage - change to mgc-sdk-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.4
 require (
 	github.com/MagaluCloud/magalu/mgc/lib v0.33.3
 	github.com/MagaluCloud/magalu/mgc/sdk v0.33.3
-	github.com/MagaluCloud/mgc-sdk-go v0.3.1
+	github.com/MagaluCloud/mgc-sdk-go v0.3.2
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.16.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/MagaluCloud/magalu/mgc/lib v0.33.3 h1:283h0A6GMxkyOSipG5n7SNQt06SmsTr
 github.com/MagaluCloud/magalu/mgc/lib v0.33.3/go.mod h1:6ZrWG4JZNTU+0bW6VZnMAd1teKf4ggnDLxBaHb5QxzY=
 github.com/MagaluCloud/magalu/mgc/sdk v0.33.3 h1:gbCHM3P0s+yr8eyyzdKq01nGmWbghB2YT0hro1njD0k=
 github.com/MagaluCloud/magalu/mgc/sdk v0.33.3/go.mod h1:XHyD9dr46r6oQxPq5dUV6pQYxaLvioTaxka7yUhB9Ms=
-github.com/MagaluCloud/mgc-sdk-go v0.3.1 h1:X5iBPh9gMQrCofn4xt2F7lkruJdLp2ek91eO4D1Ai8g=
-github.com/MagaluCloud/mgc-sdk-go v0.3.1/go.mod h1:PXuq2bK7qgNBPMfhgwQiNLgirn5GYLUc1YX3e9OuD/I=
+github.com/MagaluCloud/mgc-sdk-go v0.3.2 h1:kgwGBmg+vVUI9pYAseQiGTt3Vi54+saUiyX0HvoqZoI=
+github.com/MagaluCloud/mgc-sdk-go v0.3.2/go.mod h1:PXuq2bK7qgNBPMfhgwQiNLgirn5GYLUc1YX3e9OuD/I=
 github.com/MarvinJWendt/testza v0.1.0/go.mod h1:7AxNvlfeHP7Z/hDQ5JtE3OKYT3XFUeLCDE2DQninSqs=
 github.com/MarvinJWendt/testza v0.2.1/go.mod h1:God7bhG8n6uQxwdScay+gjm9/LnO4D3kkcZX4hv9Rp8=
 github.com/MarvinJWendt/testza v0.2.8/go.mod h1:nwIcjmr0Zz+Rcwfh3/4UhBp7ePKVhuBExvZqnKYWlII=

--- a/mgc/datasources/mgc_bs_snapshots.go
+++ b/mgc/datasources/mgc_bs_snapshots.go
@@ -67,7 +67,7 @@ func (r *DataSourceBsSnapshots) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	sdkOutputList, err := r.bsSnapshotService.List(ctx, bsSDK.ListOptions{ /*todo*/ })
+	sdkOutputList, err := r.bsSnapshotService.List(ctx, bsSDK.ListOptions{ /*TODO: Add options*/ })
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return

--- a/mgc/datasources/mgc_bs_volume.go
+++ b/mgc/datasources/mgc_bs_volume.go
@@ -145,7 +145,7 @@ func (r *DataSourceBsVolume) Read(ctx context.Context, req datasource.ReadReques
 
 	sdkOutput, err := r.bsVolume.Get(ctx, data.ID.ValueString(), []string{"volume_type", "attachment"})
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get versions", err.Error())
+		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
 	}
 

--- a/mgc/datasources/mgc_bs_volume.go
+++ b/mgc/datasources/mgc_bs_volume.go
@@ -2,13 +2,12 @@ package datasources
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	mgcSdk "github.com/MagaluCloud/magalu/mgc/lib"
-	sdkBlockStorageVolumes "github.com/MagaluCloud/magalu/mgc/lib/products/block_storage/volumes"
-	"github.com/MagaluCloud/terraform-provider-mgc/mgc/client"
+	bsSDK "github.com/MagaluCloud/mgc-sdk-go/blockstorage"
 	"github.com/MagaluCloud/terraform-provider-mgc/mgc/tfutil"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -16,8 +15,7 @@ import (
 var _ datasource.DataSource = &DataSourceBsVolume{}
 
 type DataSourceBsVolume struct {
-	sdkClient *mgcSdk.Client
-	bsVolumes sdkBlockStorageVolumes.Service
+	bsVolume bsSDK.VolumeService
 }
 
 func NewDataSourceBsVolume() datasource.DataSource {
@@ -53,18 +51,13 @@ func (r *DataSourceBsVolume) Configure(ctx context.Context, req datasource.Confi
 		return
 	}
 
-	var err error
-	var errDetail error
-	r.sdkClient, err, errDetail = client.NewSDKClient(req, resp)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			err.Error(),
-			errDetail.Error(),
-		)
+	dataConfig, ok := req.ProviderData.(tfutil.DataConfig)
+	if !ok {
+		resp.Diagnostics.AddError("Failed to configure data source", "Invalid provider data")
 		return
 	}
 
-	r.bsVolumes = sdkBlockStorageVolumes.NewService(ctx, r.sdkClient)
+	r.bsVolume = bsSDK.New(&dataConfig.CoreConfig).Volumes()
 }
 
 func (r *DataSourceBsVolume) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -150,33 +143,30 @@ func (r *DataSourceBsVolume) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	sdkOutput, err := r.bsVolumes.GetContext(ctx, sdkBlockStorageVolumes.GetParameters{
-		Id:     data.ID.ValueString(),
-		Expand: &sdkBlockStorageVolumes.GetParametersExpand{"volume_type", "attachment"}},
-		tfutil.GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkBlockStorageVolumes.GetConfigs{}))
+	sdkOutput, err := r.bsVolume.Get(ctx, data.ID.ValueString(), []string{"volume_type", "attachment"})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get versions", err.Error())
 		return
 	}
 
-	data.ID = types.StringValue(sdkOutput.Id)
+	data.ID = types.StringValue(sdkOutput.ID)
 	data.Name = types.StringValue(sdkOutput.Name)
 	data.AvailabilityZone = types.StringValue(sdkOutput.AvailabilityZone)
-	data.UpdatedAt = types.StringValue(sdkOutput.UpdatedAt)
-	data.CreatedAt = types.StringValue(sdkOutput.CreatedAt)
+	data.UpdatedAt = types.StringValue(sdkOutput.UpdatedAt.Format(time.RFC3339))
+	data.CreatedAt = types.StringValue(sdkOutput.CreatedAt.Format(time.RFC3339))
 	data.Size = types.Int64Value(int64(sdkOutput.Size))
 	data.TypeName = types.StringPointerValue(sdkOutput.Type.Name)
 	data.DiskType = types.StringPointerValue(sdkOutput.Type.DiskType)
-	data.TypeId = types.StringPointerValue(sdkOutput.Type.Id)
+	data.TypeId = types.StringValue(sdkOutput.Type.ID)
 	data.TypeStatus = types.StringPointerValue(sdkOutput.Type.Status)
 	data.State = types.StringValue(sdkOutput.State)
 	data.Status = types.StringValue(sdkOutput.Status)
-	data.Encrypted = types.BoolPointerValue(sdkOutput.Encrypted)
+	data.Encrypted = types.BoolValue(sdkOutput.Encrypted)
 	if sdkOutput.Attachment != nil {
-		data.AttachedAt = types.StringValue(sdkOutput.Attachment.AttachedAt)
+		data.AttachedAt = types.StringValue(sdkOutput.Attachment.AttachedAt.Format(time.RFC3339))
 		data.AttachedDevice = types.StringPointerValue(sdkOutput.Attachment.Device)
-		data.AttachedInstanceId = types.StringPointerValue(sdkOutput.Attachment.Instance.Id)
-		data.AttachedInstanceName = types.StringPointerValue(sdkOutput.Attachment.Instance.Name)
+		data.AttachedInstanceId = types.StringValue(sdkOutput.Attachment.Instance.ID)
+		data.AttachedInstanceName = types.StringValue(sdkOutput.Attachment.Instance.Name)
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/mgc/datasources/mgc_bs_volume_types.go
+++ b/mgc/datasources/mgc_bs_volume_types.go
@@ -104,7 +104,7 @@ func (r *DataSourceBsVolumeTypes) Read(ctx context.Context, req datasource.ReadR
 
 	sdkOutput, err := r.bsVolumeTypes.List(ctx, bsSDK.ListVolumeTypesOptions{ /*todo*/ })
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get versions", err.Error())
+		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
 	}
 

--- a/mgc/datasources/mgc_bs_volume_types.go
+++ b/mgc/datasources/mgc_bs_volume_types.go
@@ -6,9 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	mgcSdk "github.com/MagaluCloud/magalu/mgc/lib"
-	sdkBlockStorageVolumeTypes "github.com/MagaluCloud/magalu/mgc/lib/products/block_storage/volume_types"
-	"github.com/MagaluCloud/terraform-provider-mgc/mgc/client"
+	bsSDK "github.com/MagaluCloud/mgc-sdk-go/blockstorage"
 	"github.com/MagaluCloud/terraform-provider-mgc/mgc/tfutil"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -16,8 +14,7 @@ import (
 var _ datasource.DataSource = &DataSourceBsVolumeTypes{}
 
 type DataSourceBsVolumeTypes struct {
-	sdkClient     *mgcSdk.Client
-	bsVolumeTypes sdkBlockStorageVolumeTypes.Service
+	bsVolumeTypes bsSDK.VolumeTypeService
 }
 
 func NewDataSourceBsVolumeTypes() datasource.DataSource {
@@ -46,18 +43,14 @@ func (r *DataSourceBsVolumeTypes) Configure(ctx context.Context, req datasource.
 		return
 	}
 
-	var err error
-	var errDetail error
-	r.sdkClient, err, errDetail = client.NewSDKClient(req, resp)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			err.Error(),
-			errDetail.Error(),
-		)
+	dataConfig, ok := req.ProviderData.(tfutil.DataConfig)
+
+	if !ok {
+		resp.Diagnostics.AddError("Failed to configure data source", "Invalid provider data")
 		return
 	}
 
-	r.bsVolumeTypes = sdkBlockStorageVolumeTypes.NewService(ctx, r.sdkClient)
+	r.bsVolumeTypes = bsSDK.New(&dataConfig.CoreConfig).VolumeTypes()
 }
 
 func (r *DataSourceBsVolumeTypes) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -105,23 +98,25 @@ func (r *DataSourceBsVolumeTypes) Read(ctx context.Context, req datasource.ReadR
 	var data volumeTypes
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	sdkOutput, err := r.bsVolumeTypes.ListContext(ctx, sdkBlockStorageVolumeTypes.ListParameters{},
-		tfutil.GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkBlockStorageVolumeTypes.ListConfigs{}))
+	sdkOutput, err := r.bsVolumeTypes.List(ctx, bsSDK.ListVolumeTypesOptions{ /*todo*/ })
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get versions", err.Error())
 		return
 	}
 
-	for _, stype := range sdkOutput.Types {
+	for _, stype := range sdkOutput {
 		list, diags := types.ListValueFrom(ctx, types.StringType, stype.AvailabilityZones)
 		resp.Diagnostics.Append(diags...)
 
 		data.VolumeTypes = append(data.VolumeTypes, volumeType{
 			AvailabilityZones: list,
 			DiskType:          types.StringValue(stype.DiskType),
-			Id:                types.StringValue(stype.Id),
-			Iops:              types.Int64Value(int64(stype.Iops.Total)),
+			Id:                types.StringValue(stype.ID),
+			Iops:              types.Int64Value(int64(stype.IOPS.Total)),
 			Name:              types.StringValue(stype.Name),
 			Status:            types.StringValue(stype.Status),
 		})

--- a/mgc/datasources/mgc_bs_volumes.go
+++ b/mgc/datasources/mgc_bs_volumes.go
@@ -122,7 +122,7 @@ func (r *DataSourceBsVolumes) Read(ctx context.Context, req datasource.ReadReque
 
 	sdkOutputList, err := r.bsVolumes.List(ctx, bsSDK.ListOptions{ /*TODO: Add options*/ })
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get versions", err.Error())
+		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
 	}
 

--- a/mgc/datasources/mgc_bs_volumes.go
+++ b/mgc/datasources/mgc_bs_volumes.go
@@ -2,13 +2,12 @@ package datasources
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	mgcSdk "github.com/MagaluCloud/magalu/mgc/lib"
-	sdkBlockStorageVolumes "github.com/MagaluCloud/magalu/mgc/lib/products/block_storage/volumes"
-	"github.com/MagaluCloud/terraform-provider-mgc/mgc/client"
+	bsSDK "github.com/MagaluCloud/mgc-sdk-go/blockstorage"
 	"github.com/MagaluCloud/terraform-provider-mgc/mgc/tfutil"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -16,8 +15,7 @@ import (
 var _ datasource.DataSource = &DataSourceBsVolumes{}
 
 type DataSourceBsVolumes struct {
-	sdkClient *mgcSdk.Client
-	bsVolumes sdkBlockStorageVolumes.Service
+	bsVolumes bsSDK.VolumeService
 }
 
 type bsVolumesResourceItemModel struct {
@@ -50,18 +48,13 @@ func (r *DataSourceBsVolumes) Configure(ctx context.Context, req datasource.Conf
 		return
 	}
 
-	var err error
-	var errDetail error
-	r.sdkClient, err, errDetail = client.NewSDKClient(req, resp)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			err.Error(),
-			errDetail.Error(),
-		)
+	dataConfig, ok := req.ProviderData.(tfutil.DataConfig)
+	if !ok {
+		resp.Diagnostics.AddError("Failed to configure data source", "Invalid provider data")
 		return
 	}
 
-	r.bsVolumes = sdkBlockStorageVolumes.NewService(ctx, r.sdkClient)
+	r.bsVolumes = bsSDK.New(&dataConfig.CoreConfig).Volumes()
 }
 
 func (r *DataSourceBsVolumes) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -127,26 +120,25 @@ func (r *DataSourceBsVolumes) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	sdkOutputList, err := r.bsVolumes.ListContext(ctx, sdkBlockStorageVolumes.ListParameters{},
-		tfutil.GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkBlockStorageVolumes.ListConfigs{}))
+	sdkOutputList, err := r.bsVolumes.List(ctx, bsSDK.ListOptions{ /*TODO: Add options*/ })
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get versions", err.Error())
 		return
 	}
 
-	for _, sdkOutput := range sdkOutputList.Volumes {
+	for _, sdkOutput := range sdkOutputList {
 
 		var item bsVolumesResourceItemModel
-		item.ID = types.StringValue(sdkOutput.Id)
+		item.ID = types.StringValue(sdkOutput.ID)
 		item.Name = types.StringValue(sdkOutput.Name)
 		item.AvailabilityZone = types.StringValue(sdkOutput.AvailabilityZone)
-		item.UpdatedAt = types.StringValue(sdkOutput.UpdatedAt)
-		item.CreatedAt = types.StringValue(sdkOutput.CreatedAt)
+		item.UpdatedAt = types.StringValue(sdkOutput.UpdatedAt.Format(time.RFC3339))
+		item.CreatedAt = types.StringValue(sdkOutput.CreatedAt.Format(time.RFC3339))
 		item.Size = types.Int64Value(int64(sdkOutput.Size))
-		item.TypeId = types.StringPointerValue(sdkOutput.Type.Id)
+		item.TypeId = types.StringValue(sdkOutput.Type.ID)
 		item.State = types.StringValue(sdkOutput.State)
 		item.Status = types.StringValue(sdkOutput.Status)
-		item.Encrepted = types.BoolPointerValue(sdkOutput.Encrypted)
+		item.Encrepted = types.BoolValue(sdkOutput.Encrypted)
 
 		data.Volumes = append(data.Volumes, item)
 	}

--- a/mgc/provider.go
+++ b/mgc/provider.go
@@ -235,7 +235,7 @@ func NewConfigData(plan ProviderModel, tfVersion string) tfutil.DataConfig {
 
 	output.CoreConfig = *sdk.NewMgcClient(output.ApiKey,
 		sdk.WithBaseURL(sdkUrl),
-		sdk.WithUserAgent("MgcTF/"+tfVersion),
+		sdk.WithUserAgent("MgcTF/"+tfVersion+"-mgc-sdk-go"),
 	)
 
 	return output


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

```
terraform {
  required_providers {
    mgc = {
      source = "registry.terraform.io/magalucloud/mgc"
    }
  }
}

provider "mgc" {
  alias = "sudeste"
  region = "br-se1"
  api_key = "fffffffffffffff6"
}

provider "mgc" {
  alias = "nordeste"
  region = "br-ne1"
  api_key = "ddddddddd6"
}


resource "mgc_block_storage_volumes" "example_volume" {
  provider  = mgc.nordeste
  name = "example-volum33e"
  size = 10
  type = "cloud_nvme1k"
  
}

data "mgc_block_storage_volume" "myvol"{
  provider  = mgc.nordeste
  id = mgc_block_storage_volumes.example_volume.id
}

output "akaka" {
  value = data.mgc_block_storage_volume.myvol  
}

data "mgc_block_storage_volumes" "myvols"{
  provider = mgc.nordeste
}

output "myvollls"{
  value = data.mgc_block_storage_volumes.myvols
}
```