### PR TITLE
feat: datasource - containerregistry - change to mgc-sdk-go

### DIFF
--- a/mgc/datasources/mgc_cr_credentials.go
+++ b/mgc/datasources/mgc_cr_credentials.go
@@ -72,10 +72,13 @@ func (r *DataSourceCRCredentials) Read(ctx context.Context, req datasource.ReadR
 	var data crCredentials
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	sdkOutput, err := r.crCredentials.Get(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get versions", err.Error())
+		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
 	}
 

--- a/mgc/datasources/mgc_cr_images.go
+++ b/mgc/datasources/mgc_cr_images.go
@@ -109,7 +109,7 @@ func (r *DataSourceCRImages) Read(ctx context.Context, req datasource.ReadReques
 	sdkOutputList, err := r.crImages.List(ctx, data.RegistryID.ValueString(), data.RepositoryName.ValueString(), crSDK.ListOptions{ /*TODO: Add options*/ })
 
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get versions", err.Error())
+		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
 	}
 

--- a/mgc/datasources/mgc_cr_registries.go
+++ b/mgc/datasources/mgc_cr_registries.go
@@ -97,7 +97,7 @@ func (r *DataSourceCRRegistries) Read(ctx context.Context, req datasource.ReadRe
 
 	sdkOutputList, err := r.crRegistries.List(ctx, crSDK.ListOptions{ /*TODO: Add options*/ })
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get versions", err.Error())
+		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
 	}
 

--- a/mgc/datasources/mgc_cr_repositories.go
+++ b/mgc/datasources/mgc_cr_repositories.go
@@ -101,7 +101,7 @@ func (r *DataSourceCRRepositories) Read(ctx context.Context, req datasource.Read
 
 	sdkOutputList, err := r.crRepositories.List(ctx, data.RegistryID.ValueString(), crSDK.ListOptions{ /*TODO: Add options*/ })
 	if err != nil {
-		resp.Diagnostics.AddError("Failed to get versions", err.Error())
+		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
 	}
 

--- a/mgc/datasources/mgc_cr_repositories.go
+++ b/mgc/datasources/mgc_cr_repositories.go
@@ -6,17 +6,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 
-	mgcSdk "github.com/MagaluCloud/magalu/mgc/lib"
-	sdkCRRepositories "github.com/MagaluCloud/magalu/mgc/lib/products/container_registry/repositories"
-	"github.com/MagaluCloud/terraform-provider-mgc/mgc/client"
+	crSDK "github.com/MagaluCloud/mgc-sdk-go/containerregistry"
+	"github.com/MagaluCloud/terraform-provider-mgc/mgc/tfutil"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var _ datasource.DataSource = &DataSourceCRRepositories{}
 
 type DataSourceCRRepositories struct {
-	sdkClient      *mgcSdk.Client
-	crRepositories sdkCRRepositories.Service
+	crRepositories crSDK.RepositoriesService
 }
 
 func NewDataSourceCRRepositories() datasource.DataSource {
@@ -45,18 +43,13 @@ func (r *DataSourceCRRepositories) Configure(ctx context.Context, req datasource
 		return
 	}
 
-	var err error
-	var errDetail error
-	r.sdkClient, err, errDetail = client.NewSDKClient(req, resp)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			err.Error(),
-			errDetail.Error(),
-		)
+	dataConfig, ok := req.ProviderData.(tfutil.DataConfig)
+	if !ok {
+		resp.Diagnostics.AddError("Failed to configure data source", "Invalid provider data")
 		return
 	}
 
-	r.crRepositories = sdkCRRepositories.NewService(ctx, r.sdkClient)
+	r.crRepositories = crSDK.New(&dataConfig.CoreConfig).Repositories()
 }
 func (r *DataSourceCRRepositories) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
@@ -102,10 +95,11 @@ func (r *DataSourceCRRepositories) Read(ctx context.Context, req datasource.Read
 	var data crRepositoriesList
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	sdkOutputList, err := r.crRepositories.ListContext(ctx, sdkCRRepositories.ListParameters{
-		RegistryId: data.RegistryID.ValueString(),
-	}, sdkCRRepositories.ListConfigs{})
+	sdkOutputList, err := r.crRepositories.List(ctx, data.RegistryID.ValueString(), crSDK.ListOptions{ /*TODO: Add options*/ })
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to get versions", err.Error())
 		return

--- a/mgc/tfutil/sdk_validations.go
+++ b/mgc/tfutil/sdk_validations.go
@@ -2,6 +2,7 @@ package tfutil
 
 import (
 	"fmt"
+	"strings"
 
 	clientSDK "github.com/MagaluCloud/mgc-sdk-go/client"
 )
@@ -45,8 +46,10 @@ func buildFromSDKError(err *clientSDK.HTTPError) (HttpErrorResponse, error) {
 
 	if err.Response != nil && err.Response.Request != nil {
 		e.URL = err.Response.Request.URL.String()
-		if len(err.Response.Header[string(clientSDK.RequestIDKey)]) >= 1 {
-			e.RequestID = err.Response.Header[string(clientSDK.RequestIDKey)][0]
+		for key, value := range err.Response.Header {
+			if strings.ToLower(key) == string(clientSDK.RequestIDKey) {
+				e.RequestID = value[0]
+			}
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

```
terraform {
  required_providers {
    mgc = {
      source = "registry.terraform.io/magalucloud/mgc"
    }
  }
}

provider "mgc" {
  alias = "sudeste"
  region = "br-se1"
  api_key = "6"
}

provider "mgc" {
  alias = "nordeste"
  region = "br-ne1"
  api_key = "6"
}

data "mgc_container_credentials" "cred"{
  provider = mgc.sudeste
  
}

output "mycreds" {
  sensitive = true
  value = data.mgc_container_credentials.cred
  
}

data "mgc_container_registries" "registryies" {
    provider = mgc.sudeste
}

output "myregs"{
  value = data.mgc_container_registries.registryies
}

data "mgc_container_repositories" "repos" {
  provider = mgc.sudeste
  registry_id = "a6f44d78-30b4-44ea-bce6-4f11b9adac2e"
}

output "myrepos" {
  value = data.mgc_container_repositories.repos  
}

data "mgc_container_images" "images" {
  provider = mgc.sudeste
  registry_id = "a6f44d78-30b4-44ea-bce6-4f11b9adac2e"
  repository_name = "mgccli"  
}
output "myimages" {
  value = data.mgc_container_images.images
  
}
``` 