### PR TITLE
feat: implemented mgc trace id header return in responde errors validation

### DIFF
--- a/mgc/tfutil/sdk_validations.go
+++ b/mgc/tfutil/sdk_validations.go
@@ -12,21 +12,25 @@ const (
 	simpleValidationError = "Request validation failed"
 	simpleGenericError    = "An unexpected error occurred"
 	simpleMaxRetriesError = "Max HTTP retries exceeded"
+
+	MgcTraceIDKey = "x-mgc-trace-id"
 )
 
 type HttpErrorResponse struct {
-	Status    string
-	Body      string
-	URL       string
-	RequestID string
+	Status     string
+	Body       string
+	URL        string
+	RequestID  string
+	MgcTraceID string
 }
 
 func (e HttpErrorResponse) String() string {
-	return fmt.Sprintf("HTTP Error:\n  Status: %s\n  Body: %s\n  URL: %s\n  Request ID: %s",
+	return fmt.Sprintf("HTTP Error:\n  Status: %s\n  Body: %s\n  URL: %s\n  Request ID: %s\n  MGC Trace ID: %s",
 		e.Status,
 		e.Body,
 		e.URL,
 		e.RequestID,
+		e.MgcTraceID,
 	)
 }
 
@@ -49,6 +53,9 @@ func buildFromSDKError(err *clientSDK.HTTPError) (HttpErrorResponse, error) {
 		for key, value := range err.Response.Header {
 			if strings.ToLower(key) == string(clientSDK.RequestIDKey) {
 				e.RequestID = value[0]
+			}
+			if strings.ToLower(key) == string(MgcTraceIDKey) {
+				e.MgcTraceID = value[0]
 			}
 		}
 	}

--- a/mgc/tfutil/sdk_validations_test.go
+++ b/mgc/tfutil/sdk_validations_test.go
@@ -27,6 +27,7 @@ func TestParseSDKError_HTTPError(t *testing.T) {
 		},
 		Header: http.Header{
 			string(clientSDK.RequestIDKey): []string{"req-123"},
+			MgcTraceIDKey:                  []string{"trace-789"},
 		},
 	}
 	httpErr := &clientSDK.HTTPError{
@@ -40,7 +41,7 @@ func TestParseSDKError_HTTPError(t *testing.T) {
 		t.Errorf("expected message %q, got %q", simpleHttpError, msg)
 	}
 
-	expectedDetail := "HTTP Error:\n  Status: 404 Not Found\n  Body: {\"error\":\"not found\"}\n  URL: http://example.com/test\n  Request ID: req-123"
+	expectedDetail := "HTTP Error:\n  Status: 404 Not Found\n  Body: {\"error\":\"not found\"}\n  URL: http://example.com/test\n  Request ID: req-123\n  MGC Trace ID: trace-789"
 	if detail != expectedDetail {
 		t.Errorf("expected detail %q, got %q", expectedDetail, detail)
 	}
@@ -62,7 +63,7 @@ func TestParseSDKError_HTTPErrorNilResponse(t *testing.T) {
 		t.Errorf("expected message %q, got %q", simpleHttpError, msg)
 	}
 
-	expectedDetail := "HTTP Error:\n  Status: 500 Internal Server Error\n  Body: server error\n  URL: \n  Request ID: "
+	expectedDetail := "HTTP Error:\n  Status: 500 Internal Server Error\n  Body: server error\n  URL: \n  Request ID: \n  MGC Trace ID: "
 	if detail != expectedDetail {
 		t.Errorf("expected detail %q, got %q", expectedDetail, detail)
 	}
@@ -119,6 +120,7 @@ func TestParseSDKError_RetryErrorWithHTTPError(t *testing.T) {
 		},
 		Header: http.Header{
 			string(clientSDK.RequestIDKey): []string{"retry-456"},
+			MgcTraceIDKey:                  []string{"trace-123"},
 		},
 	}
 	httpErr := &clientSDK.HTTPError{
@@ -136,7 +138,7 @@ func TestParseSDKError_RetryErrorWithHTTPError(t *testing.T) {
 		t.Errorf("expected message %q, got %q", simpleMaxRetriesError, msg)
 	}
 
-	expectedHTTPDetail := "HTTP Error:\n  Status: 503 Service Unavailable\n  Body: unavailable\n  URL: http://example.com/retry\n  Request ID: retry-456"
+	expectedHTTPDetail := "HTTP Error:\n  Status: 503 Service Unavailable\n  Body: unavailable\n  URL: http://example.com/retry\n  Request ID: retry-456\n  MGC Trace ID: trace-123"
 	expectedDetail := fmt.Sprintf("Max HTTP retries exceeded at %d retries.\nLast error:\n %s", 3, expectedHTTPDetail)
 	if detail != expectedDetail {
 		t.Errorf("expected detail %q, got %q", expectedDetail, detail)


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
- Now when you a got an http error from the SDK the terraform will print the mgc trace id

![image](https://github.com/user-attachments/assets/04c70cb3-bda5-470f-9ce3-0088a294d4f8)


## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
