### PR TITLE
fix: services-ipv4-cidr param name

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -36,7 +36,7 @@ resource "mgc_kubernetes_cluster" "cluster" {
 - `description` (String) A brief description of the Kubernetes cluster.
 - `enabled_bastion` (Boolean, Deprecated) Enables the use of a bastion host for secure access to the cluster.
 - `enabled_server_group` (Boolean) Enables the use of a server group with anti-affinity policy during the creation of the cluster and its node pools.
-- `service_ip_v4_cidr` (String) The IP address range of the Kubernetes cluster service.
+- `services_ip_v4_cidr` (String) The IP address range of the Kubernetes cluster service.
 - `version` (String) The native Kubernetes version of the cluster. Use the standard "vX.Y.Z" format.
 - `zone` (String) Identifier of the zone where the Kubernetes cluster is located.
 

--- a/mgc/resources/mgc_k8s_cluster.go
+++ b/mgc/resources/mgc_k8s_cluster.go
@@ -164,7 +164,7 @@ func (r *k8sClusterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"service_ip_v4_cidr": schema.StringAttribute{
+			"services_ip_v4_cidr": schema.StringAttribute{
 				Description: "The IP address range of the Kubernetes cluster service.",
 				Optional:    true,
 				Computed:    true,


### PR DESCRIPTION
## What does this PR do?
Fixes misnaming of services ipv4 cidr param in kuernetes cluster resource

## How Has This Been Tested?
Manually by trying to create a cluster

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
