### PR TITLE
fix: DBaaS Instance Type Validations

### DIFF
--- a/mgc/datasources/mgc_dbaas_instances_snapshot.go
+++ b/mgc/datasources/mgc_dbaas_instances_snapshot.go
@@ -17,7 +17,7 @@ type DataSourceDbSnapshot struct {
 
 type dbSnapshotModel struct {
 	ID          types.String `tfsdk:"id"`
-	InstanceId  types.String `tfsdk:"instance_id"`
+	InstanceID  types.String `tfsdk:"instance_id"`
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 	CreatedAt   types.String `tfsdk:"created_at"`
@@ -89,7 +89,7 @@ func (r *DataSourceDbSnapshot) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	snapshot, err := r.snapshots.GetSnapshot(ctx, data.InstanceId.ValueString(), data.ID.ValueString())
+	snapshot, err := r.snapshots.GetSnapshot(ctx, data.InstanceID.ValueString(), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return

--- a/mgc/datasources/mgc_dbaas_instances_snapshots.go
+++ b/mgc/datasources/mgc_dbaas_instances_snapshots.go
@@ -16,7 +16,7 @@ type DataSourceDbSnapshots struct {
 }
 
 type dbSnapshotsModel struct {
-	InstanceId types.String      `tfsdk:"instance_id"`
+	InstanceID types.String      `tfsdk:"instance_id"`
 	Snapshots  []dbSnapshotModel `tfsdk:"snapshots"`
 }
 
@@ -96,7 +96,7 @@ func (r *DataSourceDbSnapshots) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	snapshots, err := r.snapshots.ListSnapshots(ctx, data.InstanceId.ValueString(), dbSDK.ListSnapshotOptions{})
+	snapshots, err := r.snapshots.ListSnapshots(ctx, data.InstanceID.ValueString(), dbSDK.ListSnapshotOptions{})
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
@@ -107,7 +107,7 @@ func (r *DataSourceDbSnapshots) Read(ctx context.Context, req datasource.ReadReq
 		snapshotModels = append(snapshotModels, dbSnapshotModel{
 			ID:          types.StringValue(snapshot.ID),
 			Name:        types.StringValue(snapshot.Name),
-			InstanceId:  data.InstanceId,
+			InstanceID:  data.InstanceID,
 			Description: types.StringValue(snapshot.Description),
 			CreatedAt:   types.StringValue(*tfutil.ConvertTimeToRFC3339(&snapshot.CreatedAt)),
 			Status:      types.StringValue(string(snapshot.Status)),

--- a/mgc/resources/mgc_dbaas_instances.go
+++ b/mgc/resources/mgc_dbaas_instances.go
@@ -54,7 +54,7 @@ func (s DBaaSInstanceStatus) IsError() bool {
 }
 
 type DBaaSInstanceModel struct {
-	Id                  types.String `tfsdk:"id"`
+	ID                  types.String `tfsdk:"id"`
 	Name                types.String `tfsdk:"name"`
 	User                types.String `tfsdk:"user"`
 	Password            types.String `tfsdk:"password"`
@@ -276,10 +276,10 @@ func (r *DBaaSInstanceResource) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	data.Id = types.StringValue(created.ID)
+	data.ID = types.StringValue(created.ID)
 	data.Password = types.StringNull()
 	data.User = types.StringNull()
-	result, err := r.waitUntilInstanceStatusMatches(ctx, data.Id.ValueString(), DBaaSInstanceStatusActive.String())
+	result, err := r.waitUntilInstanceStatusMatches(ctx, data.ID.ValueString(), DBaaSInstanceStatusActive.String())
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
@@ -295,7 +295,7 @@ func (r *DBaaSInstanceResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	instance, err := r.dbaasInstances.Get(ctx, data.Id.ValueString(), dbSDK.GetInstanceOptions{})
+	instance, err := r.dbaasInstances.Get(ctx, data.ID.ValueString(), dbSDK.GetInstanceOptions{})
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
@@ -355,7 +355,7 @@ func (r *DBaaSInstanceResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 
-		_, err = r.dbaasInstances.Resize(ctx, currentData.Id.ValueString(), dbSDK.InstanceResizeRequest{
+		_, err = r.dbaasInstances.Resize(ctx, currentData.ID.ValueString(), dbSDK.InstanceResizeRequest{
 			InstanceTypeID: &instanceTypeID,
 		})
 		if err != nil {
@@ -363,7 +363,7 @@ func (r *DBaaSInstanceResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 
-		if _, err := r.waitUntilInstanceStatusMatches(ctx, planData.Id.ValueString(), DBaaSInstanceStatusActive.String()); err != nil {
+		if _, err := r.waitUntilInstanceStatusMatches(ctx, planData.ID.ValueString(), DBaaSInstanceStatusActive.String()); err != nil {
 			resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 			return
 		}
@@ -371,7 +371,7 @@ func (r *DBaaSInstanceResource) Update(ctx context.Context, req resource.UpdateR
 
 	if planData.VolumeSize.ValueInt64() != currentData.VolumeSize.ValueInt64() {
 		currentData.VolumeSize = planData.VolumeSize
-		_, err := r.dbaasInstances.Resize(ctx, currentData.Id.ValueString(), dbSDK.InstanceResizeRequest{
+		_, err := r.dbaasInstances.Resize(ctx, currentData.ID.ValueString(), dbSDK.InstanceResizeRequest{
 			Volume: &dbSDK.InstanceVolumeResizeRequest{
 				Size: *tfutil.ConvertInt64PointerToIntPointer(planData.VolumeSize.ValueInt64Pointer()),
 			},
@@ -381,7 +381,7 @@ func (r *DBaaSInstanceResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 
-		if _, err := r.waitUntilInstanceStatusMatches(ctx, planData.Id.ValueString(), DBaaSInstanceStatusActive.String()); err != nil {
+		if _, err := r.waitUntilInstanceStatusMatches(ctx, planData.ID.ValueString(), DBaaSInstanceStatusActive.String()); err != nil {
 			resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 			return
 		}
@@ -391,7 +391,7 @@ func (r *DBaaSInstanceResource) Update(ctx context.Context, req resource.UpdateR
 		currentData.BackupRetentionDays = planData.BackupRetentionDays
 		currentData.BackupStartAt = planData.BackupStartAt
 
-		_, err := r.dbaasInstances.Update(ctx, planData.Id.ValueString(), dbSDK.DatabaseInstanceUpdateRequest{
+		_, err := r.dbaasInstances.Update(ctx, planData.ID.ValueString(), dbSDK.DatabaseInstanceUpdateRequest{
 			BackupRetentionDays: tfutil.ConvertInt64PointerToIntPointer(planData.BackupRetentionDays.ValueInt64Pointer()),
 			BackupStartAt:       planData.BackupStartAt.ValueStringPointer(),
 		})
@@ -400,7 +400,7 @@ func (r *DBaaSInstanceResource) Update(ctx context.Context, req resource.UpdateR
 			return
 		}
 
-		if _, err := r.waitUntilInstanceStatusMatches(ctx, planData.Id.ValueString(), DBaaSInstanceStatusActive.String()); err != nil {
+		if _, err := r.waitUntilInstanceStatusMatches(ctx, planData.ID.ValueString(), DBaaSInstanceStatusActive.String()); err != nil {
 			resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 			return
 		}
@@ -416,7 +416,7 @@ func (r *DBaaSInstanceResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	err := r.dbaasInstances.Delete(ctx, data.Id.ValueString())
+	err := r.dbaasInstances.Delete(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
@@ -425,7 +425,7 @@ func (r *DBaaSInstanceResource) Delete(ctx context.Context, req resource.DeleteR
 
 func (r *DBaaSInstanceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	data := DBaaSInstanceModel{}
-	data.Id = types.StringValue(req.ID)
+	data.ID = types.StringValue(req.ID)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/mgc/resources/mgc_dbaas_instances.go
+++ b/mgc/resources/mgc_dbaas_instances.go
@@ -430,10 +430,7 @@ func (r *DBaaSInstanceResource) ImportState(ctx context.Context, req resource.Im
 }
 
 func (r *DBaaSInstanceResource) validateAndGetEngineID(ctx context.Context, engineName string, engineVersion string) (string, error) {
-	active := "ACTIVE"
-	engines, err := r.dbaasEngines.List(ctx, dbSDK.ListEngineOptions{
-		Status: &active,
-	})
+	engines, err := r.dbaasEngines.List(ctx, dbSDK.ListEngineOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -446,11 +443,9 @@ func (r *DBaaSInstanceResource) validateAndGetEngineID(ctx context.Context, engi
 }
 
 func (r *DBaaSInstanceResource) validateAndGetInstanceTypeID(ctx context.Context, instanceType string, engineID string) (string, error) {
-	active := "ACTIVE"
 	maxLimit := 50
 	instanceTypes, err := r.dbaasInstanceTypes.List(ctx, dbSDK.ListInstanceTypeOptions{
 		Limit:    &maxLimit,
-		Status:   &active,
 		EngineID: &engineID,
 	})
 	if err != nil {

--- a/mgc/resources/mgc_dbaas_instances_snapshots.go
+++ b/mgc/resources/mgc_dbaas_instances_snapshots.go
@@ -35,8 +35,8 @@ func (s DBaaSInstanceSnapshotStatus) String() string {
 }
 
 type DBaaSInstanceSnapshotModel struct {
-	Id          types.String `tfsdk:"id"`
-	InstanceId  types.String `tfsdk:"instance_id"`
+	ID          types.String `tfsdk:"id"`
+	InstanceID  types.String `tfsdk:"instance_id"`
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 }
@@ -106,7 +106,7 @@ func (r *DBaaSInstanceSnapshotResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	created, err := r.instanceService.CreateSnapshot(ctx, data.InstanceId.ValueString(), dbSDK.SnapshotCreateRequest{
+	created, err := r.instanceService.CreateSnapshot(ctx, data.InstanceID.ValueString(), dbSDK.SnapshotCreateRequest{
 		Name:        data.Name.ValueString(),
 		Description: data.Description.ValueStringPointer(),
 	})
@@ -115,9 +115,9 @@ func (r *DBaaSInstanceSnapshotResource) Create(ctx context.Context, req resource
 		return
 	}
 
-	data.Id = types.StringValue(created.ID)
+	data.ID = types.StringValue(created.ID)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-	err = r.waitUntilSnapshotStatusMatches(ctx, data.InstanceId.ValueString(), created.ID, DBaaSInstanceSnapshotStatusAvailable)
+	err = r.waitUntilSnapshotStatusMatches(ctx, data.InstanceID.ValueString(), created.ID, DBaaSInstanceSnapshotStatusAvailable)
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
@@ -131,7 +131,7 @@ func (r *DBaaSInstanceSnapshotResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	snapshot, err := r.instanceService.GetSnapshot(ctx, data.InstanceId.ValueString(), data.Id.ValueString())
+	snapshot, err := r.instanceService.GetSnapshot(ctx, data.InstanceID.ValueString(), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
@@ -159,8 +159,8 @@ func (r *DBaaSInstanceSnapshotResource) Update(ctx context.Context, req resource
 	currentData.Description = planData.Description
 
 	_, err := r.instanceService.UpdateSnapshot(ctx,
-		currentData.InstanceId.ValueString(),
-		currentData.Id.ValueString(),
+		currentData.InstanceID.ValueString(),
+		currentData.ID.ValueString(),
 		dbSDK.SnapshotUpdateRequest{
 			Name:        planData.Name.ValueString(),
 			Description: planData.Description.ValueStringPointer(),
@@ -181,7 +181,7 @@ func (r *DBaaSInstanceSnapshotResource) Delete(ctx context.Context, req resource
 		return
 	}
 
-	err := r.instanceService.DeleteSnapshot(ctx, data.InstanceId.ValueString(), data.Id.ValueString())
+	err := r.instanceService.DeleteSnapshot(ctx, data.InstanceID.ValueString(), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
 		return
@@ -199,8 +199,8 @@ func (r *DBaaSInstanceSnapshotResource) ImportState(ctx context.Context, req res
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &DBaaSInstanceSnapshotModel{
-		InstanceId: types.StringValue(ids[0]),
-		Id:         types.StringValue(ids[1])})...)
+		InstanceID: types.StringValue(ids[0]),
+		ID:         types.StringValue(ids[1])})...)
 }
 
 func (r *DBaaSInstanceSnapshotResource) waitUntilSnapshotStatusMatches(ctx context.Context, instanceID string, snapshotID string, status DBaaSInstanceSnapshotStatus) error {

--- a/mgc/resources/mgc_dbaas_parameter_groups.go
+++ b/mgc/resources/mgc_dbaas_parameter_groups.go
@@ -192,10 +192,7 @@ func (r *DBaaSParameterGroupsResource) ImportState(ctx context.Context, req reso
 }
 
 func (r *DBaaSParameterGroupsResource) validateAndGetEngineID(ctx context.Context, engineName string, engineVersion string) (string, error) {
-	active := "ACTIVE"
-	engines, err := r.dbaasEngines.List(ctx, dbSDK.ListEngineOptions{
-		Status: &active,
-	})
+	engines, err := r.dbaasEngines.List(ctx, dbSDK.ListEngineOptions{})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What does this PR do?
Fix some DBaaS flows:
- create DB for all available engines
- correct request for replica resize
- wait for replica status to be ACTIVE during a resize
- create and resize replica by instance-type name instead of instance-type ID
- rename variables accordingly with the dbaas_instances source file

## How Has This Been Tested?
Creating, resizing, and removing DBs for:
- MySQL 8.0
- MySQL 8.4
- Postgresql 16

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
