### PR TITLE
fix: paramter group update

### DIFF
--- a/mgc/resources/mgc_dbaas_parameters.go
+++ b/mgc/resources/mgc_dbaas_parameters.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	dbSDK "github.com/MagaluCloud/mgc-sdk-go/dbaas"
@@ -155,14 +156,17 @@ func (r *DBaaSParameterResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	currentData.Value = data.Value
-	_, err = r.ParameterService.Update(ctx, currentData.ParameterGroupID.ValueString(), currentData.ID.ValueString(), dbSDK.ParameterUpdateRequest{
-		Value: s,
-	})
-	if err != nil {
-		resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
-		return
+	updatedValue := fmt.Sprintf("%v", s)
+	if updatedValue != currentData.Value.String() {
+		_, err = r.ParameterService.Update(ctx, currentData.ParameterGroupID.ValueString(), currentData.ID.ValueString(), dbSDK.ParameterUpdateRequest{
+			Value: s,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(tfutil.ParseSDKError(err))
+			return
+		}
 	}
+	currentData.Value = data.Value
 	resp.Diagnostics.Append(resp.State.Set(ctx, &currentData)...)
 }
 


### PR DESCRIPTION
## What does this PR do?
Due to the dynamic nature of the value parameter in the parameters resource, it would always trigger a resource update. This consistently puts the database into a pending administrative state, requiring an unnecessary restart.

## How Has This Been Tested?
Creating and updating a database with parameter group resource associated with parameters in it. It was verified that when there is no parameter resources changes, the database administrative state remains the same.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
