### PR TITLE
fix: adjust k8s cluster cidr ipv4 name pattern

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -31,10 +31,10 @@ resource "mgc_kubernetes_cluster" "cluster" {
 ### Optional
 
 - `allowed_cidrs` (List of String) List of allowed CIDR blocks for API server access.
-- `cluster_ip_v4_cidr` (String) The IP address range of the Kubernetes cluster.
+- `cluster_ipv4_cidr` (String) The IP address range of the Kubernetes cluster.
 - `description` (String) A brief description of the Kubernetes cluster.
 - `enabled_server_group` (Boolean) Enables the use of a server group with anti-affinity policy during the creation of the cluster and its node pools. Default is true.
-- `services_ip_v4_cidr` (String) The IP address range of the Kubernetes cluster service.
+- `services_ipv4_cidr` (String) The IP address range of the Kubernetes cluster service.
 - `version` (String) The native Kubernetes version of the cluster. Use the standard "vX.Y.Z" format.
 
 ### Read-Only

--- a/mgc/resources/mgc_k8s_cluster.go
+++ b/mgc/resources/mgc_k8s_cluster.go
@@ -34,8 +34,8 @@ type KubernetesClusterCreateResourceModel struct {
 	Version            types.String   `tfsdk:"version"`
 	CreatedAt          types.String   `tfsdk:"created_at"`
 	ID                 types.String   `tfsdk:"id"`
-	ServicesIpV4CIDR   types.String   `tfsdk:"services_ip_v4_cidr"`
-	ClusterIPv4CIDR    types.String   `tfsdk:"cluster_ip_v4_cidr"`
+	ServicesIpV4CIDR   types.String   `tfsdk:"services_ipv4_cidr"`
+	ClusterIPv4CIDR    types.String   `tfsdk:"cluster_ipv4_cidr"`
 }
 
 type k8sClusterResource struct {
@@ -122,7 +122,7 @@ func (r *k8sClusterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"cluster_ip_v4_cidr": schema.StringAttribute{
+			"cluster_ipv4_cidr": schema.StringAttribute{
 				Description: "The IP address range of the Kubernetes cluster.",
 				Optional:    true,
 				Computed:    true,
@@ -131,7 +131,7 @@ func (r *k8sClusterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"services_ip_v4_cidr": schema.StringAttribute{
+			"services_ipv4_cidr": schema.StringAttribute{
 				Description: "The IP address range of the Kubernetes cluster service.",
 				Optional:    true,
 				Computed:    true,


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
- Fix the k8s cluster resource with the correct name for cidr ipv4 fields

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
