### PR TITLE
fix: plan does not changes with recalculated instance_type_id

### DIFF
--- a/mgc/resources/mgc_dbaas_clusters.go
+++ b/mgc/resources/mgc_dbaas_clusters.go
@@ -162,9 +162,6 @@ func (r *DBaaSClusterResource) Schema(_ context.Context, _ resource.SchemaReques
 			"engine_id": schema.StringAttribute{
 				Description: "ID of the database engine.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"instance_type": schema.StringAttribute{
 				Description: "Compute and memory capacity of the cluster nodes (e.g., 'BV1-4-10'). Cannot be changed after creation.",
@@ -179,9 +176,6 @@ func (r *DBaaSClusterResource) Schema(_ context.Context, _ resource.SchemaReques
 			"instance_type_id": schema.StringAttribute{
 				Description: "ID of the instance type.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"volume_size": schema.Int64Attribute{
 				Description: "Size of the storage volume in GB. Cannot be changed after creation.",

--- a/mgc/resources/mgc_dbaas_instances.go
+++ b/mgc/resources/mgc_dbaas_instances.go
@@ -186,9 +186,6 @@ func (r *DBaaSInstanceResource) Schema(_ context.Context, _ resource.SchemaReque
 			"engine_id": schema.StringAttribute{
 				Description: "Unique identifier for the database engine.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"instance_type": schema.StringAttribute{
 				Description: "Compute and memory capacity of the instance (e.g., 'BV1-4-10'). Can be changed to scale the instance.",
@@ -200,9 +197,6 @@ func (r *DBaaSInstanceResource) Schema(_ context.Context, _ resource.SchemaReque
 			"instance_type_id": schema.StringAttribute{
 				Description: "Unique identifier for the instance.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"volume_size": schema.Int64Attribute{
 				Description: "Size of the storage volume in GB. Can be increased but not decreased after creation.",


### PR DESCRIPTION
## What does this PR do?
Fix the retype process for single instances and clusters.

Error found during execution:
```
mgc_dbaas_instances.single_instance: Still modifying... [id=96d83e0c-b0c7-49dd-b7e9-6dba7631c9dd, 04m20s elapsed]
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to mgc_dbaas_instances.single_instance, provider "provider[\"registry.terraform.io/magalucloud/mgc\"]" produced an unexpected new
│ value: .instance_type_id: was cty.StringVal("c6fdf799-a8a7-48b8-ae59-11c416a303b3"), but now cty.StringVal("623c4617-cffc-4953-879e-bba12ef0ab28").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

## How Has This Been Tested?
Requested a successfully instance and replica change of instance-type (this feature is not available for cluster right now).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
