### PR TITLE
docs: fix volume units, add punctuations and fix misspellings

### DIFF
--- a/docs-extra/guides/vm-volumes.md
+++ b/docs-extra/guides/vm-volumes.md
@@ -63,7 +63,7 @@ That's it! The volume is now attached to your VM. After the infrastructure is pr
 
 ## Creating Volume Snapshots
 
-Snapshots let you create point-in-time backups of your volumes. They're useful for data backup, cloning environments, or disaster recovery.
+Snapshots let you create point-in-time backups of your volumes. They are useful for data backup, cloning environments, or disaster recovery.
 
 ### 1. Creating a Snapshot of an Attached Volume
 

--- a/docs/data-sources/block_storage_snapshot.md
+++ b/docs/data-sources/block_storage_snapshot.md
@@ -35,7 +35,7 @@ output "snapshot" {
 - `created_at` (String) The timestamp when the block storage was created.
 - `description` (String) The description of the volume snapshot.
 - `name` (String) The name of the volume snapshot.
-- `size` (Number) The size of the snapshot in GB.
+- `size` (Number) The size of the snapshot in GiB.
 - `state` (String) The current state of the virtual machine instance.
 - `status` (String) The status of the virtual machine instance.
 - `type` (String) The type of the snapshot.

--- a/docs/data-sources/block_storage_snapshots.md
+++ b/docs/data-sources/block_storage_snapshots.md
@@ -39,7 +39,7 @@ Read-Only:
 - `description` (String) The description of the volume snapshot.
 - `id` (String) The unique identifier of the volume snapshot.
 - `name` (String) The name of the volume snapshot.
-- `size` (Number) The size of the snapshot in GB.
+- `size` (Number) The size of the snapshot in GiB.
 - `state` (String) The current state of the virtual machine instance.
 - `status` (String) The status of the virtual machine instance.
 - `type` (String) The type of the snapshot.

--- a/docs/data-sources/block_storage_volume.md
+++ b/docs/data-sources/block_storage_volume.md
@@ -41,7 +41,7 @@ output "my-volume" {
 - `disk_type` (String) The disk type of the block storage.
 - `encrypted` (Boolean) The encryption status of the block storage.
 - `name` (String) The name of the block storage.
-- `size` (Number) The size of the block storage in GB.
+- `size` (Number) The size of the block storage in GiB.
 - `state` (String) The current state of the virtual machine instance.
 - `status` (String) The status of the virtual machine instance.
 - `type_id` (String) The unique identifier of the block storage type.

--- a/docs/data-sources/block_storage_volumes.md
+++ b/docs/data-sources/block_storage_volumes.md
@@ -39,7 +39,7 @@ Read-Only:
 - `encrypted` (Boolean) The encryption status of the block storage.
 - `id` (String) The unique identifier of the volume snapshot.
 - `name` (String) The name of the block storage.
-- `size` (Number) The size of the block storage in GB.
+- `size` (Number) The size of the block storage in GiB.
 - `state` (String) The current state of the virtual machine instance.
 - `status` (String) The status of the virtual machine instance.
 - `type_id` (String) The unique identifier of the block storage type.

--- a/docs/data-sources/dbaas_replica.md
+++ b/docs/data-sources/dbaas_replica.md
@@ -39,7 +39,7 @@ data "mgc_dbaas_replica" "replica" {
 - `started_at` (String) Start timestamp in RFC3339 format
 - `status` (String) Current replica status
 - `updated_at` (String) Last update timestamp in RFC3339 format
-- `volume_size` (Number) Volume size in GB
+- `volume_size` (Number) Volume size in GiB
 - `volume_type` (String) Volume type
 
 <a id="nestedatt--addresses"></a>

--- a/docs/data-sources/dbaas_replicas.md
+++ b/docs/data-sources/dbaas_replicas.md
@@ -42,7 +42,7 @@ Read-Only:
 - `started_at` (String) Start timestamp
 - `status` (String) Current status
 - `updated_at` (String) Last update timestamp
-- `volume_size` (Number) Volume size in GB
+- `volume_size` (Number) Volume size in GiB
 - `volume_type` (String) Volume type
 
 <a id="nestedatt--replicas--addresses"></a>

--- a/docs/data-sources/kubernetes_nodepool.md
+++ b/docs/data-sources/kubernetes_nodepool.md
@@ -37,12 +37,12 @@ output "nodepool" {
 - `auto_scale_min_replicas` (Number) Minimum number of replicas for auto-scaling.
 - `availability_zones` (List of String) List of availability zones.
 - `created_at` (String) Creation timestamp.
-- `instance_template_disk_size` (Number) Disk size in GB for the instance template.
+- `instance_template_disk_size` (Number) Disk size in GiB for the instance template.
 - `instance_template_disk_type` (String) Disk type for the instance template.
 - `instance_template_flavor_id` (String) Flavor ID for the instance template.
 - `instance_template_flavor_name` (String) Flavor name for the instance template.
 - `instance_template_flavor_ram` (Number) RAM in MB for the instance template flavor.
-- `instance_template_flavor_size` (Number) Size in GB for the instance template flavor.
+- `instance_template_flavor_size` (Number) Size in GiB for the instance template flavor.
 - `instance_template_flavor_vcpu` (Number) Number of vCPUs for the instance template flavor.
 - `instance_template_node_image` (String) Node image for the instance template.
 - `labels` (Map of String) Labels attached to the nodepool.

--- a/docs/guides/dbaas-creation.md
+++ b/docs/guides/dbaas-creation.md
@@ -35,7 +35,7 @@ Key parameters:
 - `password`: Strong password meeting complexity requirements
 - `engine_name/version`: Database type and version
 - `instance_type`: Determines compute resources allocated
-- `volume_size`: Storage capacity in GB
+- `volume_size`: Storage capacity in GiB
 - `backup_*`: Configures automatic backups
 
 ## Creating a Database Cluster

--- a/docs/guides/vm-volumes.md
+++ b/docs/guides/vm-volumes.md
@@ -19,8 +19,8 @@ First, let's create a block storage volume:
 ```terraform
 resource "mgc_block_storage_volumes" "data_volume" {
   name              = "data-volume"
-  availability_zone = "br-ne1-a"  # Make sure this matches your VM's availability zone
-  size              = 100         # Size in GB
+  availability_zone = "br-ne1-a"  # Make sure this matches your VM availability zone
+  size              = 100         # Size in GiB
   type              = "cloud_nvme1k"
   encrypted         = true        # Optional: Enable encryption
 }
@@ -29,7 +29,7 @@ resource "mgc_block_storage_volumes" "data_volume" {
 Key parameters:
 
 - `name`: A descriptive name for your volume
-- `size`: Storage capacity in GB
+- `size`: Storage capacity in GiB
 - `type`: Performance characteristics (e.g., "cloud_nvme1k" for NVMe SSD)
 - `availability_zone`: Must match the zone where your VM is deployed
 - `encrypted`: Whether to encrypt the volume data (optional)
@@ -63,7 +63,7 @@ That's it! The volume is now attached to your VM. After the infrastructure is pr
 
 ## Creating Volume Snapshots
 
-Snapshots let you create point-in-time backups of your volumes. They're useful for data backup, cloning environments, or disaster recovery.
+Snapshots let you create point-in-time backups of your volumes. They are useful for data backup, cloning environments, or disaster recovery.
 
 ### 1. Creating a Snapshot of an Attached Volume
 

--- a/docs/resources/block_storage_volumes.md
+++ b/docs/resources/block_storage_volumes.md
@@ -27,7 +27,7 @@ resource "mgc_block_storage_volumes" "example_volume" {
 ### Required
 
 - `name` (String) The name of the volume.
-- `size` (Number) The size of the volume in GB.
+- `size` (Number) The size of the volume in GiB.
 - `type` (String) The name of the volume type.
 
 ### Optional

--- a/docs/resources/dbaas_instances.md
+++ b/docs/resources/dbaas_instances.md
@@ -39,7 +39,7 @@ resource "mgc_dbaas_instances" "test_instance" {
 - `name` (String) Name of the DBaaS instance. Must be unique within your account. Cannot be changed after creation.
 - `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Master password for the database. Must be at least 8 characters long and contain letters, numbers and special characters.
 - `user` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Master username for the database. Must start with a letter and contain only alphanumeric characters.
-- `volume_size` (Number) Size of the storage volume in GB. Can be increased but not decreased after creation.
+- `volume_size` (Number) Size of the storage volume in GiB. Can be increased but not decreased after creation.
 
 ### Optional
 


### PR DESCRIPTION
## What does this PR do?
- [docs: cloud units are in GiB instead of GB](https://github.com/MagaluCloud/terraform-provider-mgc/commit/34c129a8e434019ca80557a0c9e3fad0de270275)


## How Has This Been Tested?
(BS Volume, please, see size](https://docs.magalu.cloud/api/block-storage/#tag/volumes/operation/list_volume_v1_v1_volumes_get)
(DBaaS Volume, please, see response for status 200 > volume > size]( https://docs.magalu.cloud/api/database/#tag/instances/operation/instances_v1_get_by_id)


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
