### PR TITLE
feat: Add region parameter and fix zone conversion

### DIFF
--- a/docs/resources/kubernetes_nodepool.md
+++ b/docs/resources/kubernetes_nodepool.md
@@ -35,9 +35,7 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
 
 ### Optional
 
-> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
-
-- `availability_zones` (List of String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) List of availability zones where the node pool is deployed.
+- `availability_zones` (Set of String) List of availability zones where the node pool is deployed.
 - `max_pods_per_node` (Number) Maximum number of pods per node.
 - `max_replicas` (Number) Maximum number of replicas for autoscaling.
 - `min_replicas` (Number) Minimum number of replicas for autoscaling.

--- a/mgc/datasources/mgc_k8s_cluster_test.go
+++ b/mgc/datasources/mgc_k8s_cluster_test.go
@@ -1,0 +1,203 @@
+package datasources
+
+import (
+	"testing"
+	"time"
+
+	sdkK8s "github.com/MagaluCloud/mgc-sdk-go/kubernetes"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func stringPtr(s string) *string { return &s }
+func intPtr(i int) *int          { return &i }
+func boolPtr(b bool) *bool       { return &b }
+
+func TestConvertToControlplane(t *testing.T) {
+	t.Run("should return empty struct for nil input", func(t *testing.T) {
+		result := convertToControlplane(nil)
+		assert.NotNil(t, result)
+		assert.Equal(t, &Controlplane{}, result)
+	})
+
+	t.Run("should handle minimal sdk input correctly", func(t *testing.T) {
+		sdkCP := &sdkK8s.NodePool{
+			ID: "cp-id-123",
+			InstanceTemplate: sdkK8s.InstanceTemplate{
+				DiskSize: 50,
+				DiskType: "ssd",
+				Flavor: sdkK8s.Flavor{
+					ID:   "flavor-id-abc",
+					Name: "c1.small",
+				},
+				NodeImage: "ubuntu-22.04",
+			},
+			Name:     "controlplane-0",
+			Replicas: 1,
+			Status:   sdkK8s.Status{State: "Running"},
+		}
+
+		result := convertToControlplane(sdkCP)
+
+		assert.NotNil(t, result)
+		assert.Equal(t, types.StringValue("cp-id-123"), result.ID)
+		assert.Equal(t, types.StringValue("c1.small"), result.FlavorName)
+		assert.Equal(t, types.Int64Value(1), result.Replicas)
+		assert.Equal(t, types.StringValue("Running"), result.State)
+
+		assert.True(t, result.MaxReplicas.IsNull())
+		assert.True(t, result.MinReplicas.IsNull())
+		assert.True(t, result.Labels.IsNull())
+		assert.Nil(t, result.SecurityGroups)
+		assert.Nil(t, result.Tags)
+		assert.Nil(t, result.Taints)
+		assert.Nil(t, result.Zone)
+	})
+
+	maxReplicas := 5
+	minReplicas := 2
+	t.Run("should convert full sdk input correctly", func(t *testing.T) {
+		now := time.Now()
+		sdkCP := &sdkK8s.NodePool{
+			ID: "cp-id-123",
+			InstanceTemplate: sdkK8s.InstanceTemplate{
+				DiskSize: 50,
+				DiskType: "ssd",
+				Flavor: sdkK8s.Flavor{
+					ID:   "flavor-id-abc",
+					Name: "c1.small",
+				},
+				NodeImage: "ubuntu-22.04",
+			},
+			Name:      "controlplane-0",
+			Replicas:  3,
+			CreatedAt: &now,
+			UpdatedAt: &now,
+			AutoScale: &sdkK8s.AutoScale{
+				MaxReplicas: &maxReplicas,
+				MinReplicas: &minReplicas,
+			},
+			SecurityGroups: &[]string{"sg-default"},
+			Status: sdkK8s.Status{
+				State:    "Running",
+				Messages: []string{"ok"},
+			},
+			Tags: &[]string{"env:prod"},
+			Taints: &[]sdkK8s.Taint{
+				{Effect: "NoSchedule", Key: "app", Value: "critical"},
+			},
+			Zone: &[]string{"br-se1-a"},
+		}
+
+		result := convertToControlplane(sdkCP)
+		expectedTime := types.StringValue(now.Format(time.RFC3339))
+
+		assert.NotNil(t, result)
+		assert.Equal(t, types.StringValue("cp-id-123"), result.ID)
+		assert.Equal(t, types.Int64Value(50), result.DiskSize)
+		assert.Equal(t, types.Int64Value(3), result.Replicas)
+		assert.Equal(t, expectedTime, result.CreatedAt)
+		assert.Equal(t, expectedTime, result.UpdatedAt)
+		assert.Equal(t, types.Int64Value(5), result.MaxReplicas)
+		assert.Equal(t, types.Int64Value(2), result.MinReplicas)
+		assert.Equal(t, types.StringValue("sg-default"), result.SecurityGroups[0])
+		assert.Equal(t, types.StringValue("ok"), result.StatusMessages[0])
+		assert.Equal(t, types.StringValue("env:prod"), result.Tags[0])
+		assert.Equal(t, "NoSchedule", result.Taints[0].Effect.ValueString())
+		assert.Equal(t, "app", result.Taints[0].Key.ValueString())
+		assert.Equal(t, "critical", result.Taints[0].Value.ValueString())
+		assert.Equal(t, types.StringValue("br-se1-a"), result.Zone[0])
+	})
+}
+
+func TestConvertToKubernetesCluster(t *testing.T) {
+	t.Run("should return nil for nil input", func(t *testing.T) {
+		result := convertToKubernetesCluster(nil, "br-se1")
+		assert.Nil(t, result)
+	})
+
+	t.Run("should handle minimal sdk input correctly", func(t *testing.T) {
+		region := "br-se1"
+		sdkCluster := &sdkK8s.Cluster{
+			ID:      "cluster-id-123",
+			Name:    "test-cluster",
+			Version: "1.28.0",
+			Region:  &region,
+		}
+
+		result := convertToKubernetesCluster(sdkCluster, "br-se1")
+
+		assert.NotNil(t, result)
+		assert.Equal(t, types.StringValue("cluster-id-123"), result.ID)
+		assert.Equal(t, types.StringValue("test-cluster"), result.Name)
+		assert.Equal(t, types.StringValue("1.28.0"), result.Version)
+
+		assert.True(t, result.Description.IsNull())
+		assert.Nil(t, result.AllowedCIDRs)
+		assert.True(t, result.KubeAPIPort.IsNull())
+		assert.Nil(t, result.NodePools)
+		assert.Nil(t, result.Controlplane)
+	})
+
+	t.Run("should convert full sdk input correctly", func(t *testing.T) {
+		now := time.Now()
+		sdkCluster := &sdkK8s.Cluster{
+			ID:          "cluster-id-123",
+			Name:        "prod-cluster",
+			Description: stringPtr("Production cluster"),
+			Version:     "1.28.0",
+			Region:      stringPtr("br-se1"),
+			CreatedAt:   &now,
+			UpdatedAt:   &now,
+			AllowedCIDRs: &[]string{
+				"192.168.1.0/24",
+			},
+			Addons: &sdkK8s.Addons{
+				Loadbalance: stringPtr("enabled"),
+				Secrets:     stringPtr("enabled"),
+				Volume:      stringPtr("enabled"),
+			},
+			KubeApiServer: &sdkK8s.KubeApiServer{
+				DisableApiServerFip: boolPtr(false),
+				FixedIp:             stringPtr("10.0.0.5"),
+				FloatingIp:          stringPtr("200.1.2.3"),
+				Port:                intPtr(6443),
+			},
+			Network: &sdkK8s.Network{
+				CIDR:     "10.244.0.0/16",
+				Name:     stringPtr("prod-net"),
+				SubnetID: "subnet-id-abc",
+			},
+			Status: &sdkK8s.MessageState{
+				Message: "Cluster is healthy",
+				State:   "Running",
+			},
+			NodePools: &[]sdkK8s.NodePool{
+				{ID: "np-1", Name: "worker-pool-1"},
+			},
+			ControlPlane: &sdkK8s.NodePool{
+				ID: "cp-1",
+			},
+		}
+
+		result := convertToKubernetesCluster(sdkCluster, "br-se1")
+		expectedTime := types.StringValue(now.Format(time.RFC3339))
+
+		assert.NotNil(t, result)
+		assert.Equal(t, types.StringValue("cluster-id-123"), result.ID)
+		assert.Equal(t, types.StringValue("Production cluster"), result.Description)
+		assert.Equal(t, expectedTime, result.CreatedAt)
+		assert.Equal(t, expectedTime, result.UpdatedAt)
+		assert.Equal(t, types.StringValue("192.168.1.0/24"), result.AllowedCIDRs[0])
+		assert.Equal(t, types.StringValue("enabled"), result.AddonsLoadbalance)
+		assert.Equal(t, types.BoolValue(false), result.KubeAPIDisableAPIServerFIP)
+		assert.Equal(t, types.StringValue("200.1.2.3"), result.KubeAPIFloatingIP)
+		assert.Equal(t, types.Int64Value(6443), result.KubeAPIPort)
+		assert.Equal(t, types.StringValue("10.244.0.0/16"), result.CIDR)
+		assert.Equal(t, types.StringValue("subnet-id-abc"), result.SubnetID)
+		assert.Equal(t, types.StringValue("Running"), result.State)
+		assert.Equal(t, types.StringValue("np-1"), result.NodePools[0].ID)
+		assert.Equal(t, types.StringValue("cp-1"), result.Controlplane.ID)
+	})
+}

--- a/mgc/datasources/mgc_k8s_nodepool_test.go
+++ b/mgc/datasources/mgc_k8s_nodepool_test.go
@@ -1,0 +1,199 @@
+package datasources
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	sdkK8s "github.com/MagaluCloud/mgc-sdk-go/kubernetes"
+
+	"github.com/MagaluCloud/terraform-provider-mgc/mgc/tfutil"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestConvertGetResultToFlattened(t *testing.T) {
+	ctx := context.Background()
+	testTime := time.Date(2025, 8, 11, 14, 56, 0, 0, time.UTC)
+	testTimeString := testTime.Format(time.RFC3339)
+
+	maxPods := 110
+	minReplicas := 1
+	maxReplicas := 5
+
+	expectedLabels, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{"env": "prod", "tier": "frontend"})
+	expectedEmptyLabels, _ := types.MapValueFrom(ctx, types.StringType, map[string]string{})
+
+	testCases := []struct {
+		name           string
+		inputSDK       *sdkK8s.NodePool
+		inputClusterID string
+		inputRegion    string
+		expectedResult FlattenedGetResult
+		expectPanic    bool
+	}{
+		{
+			name:           "success: nil input returns empty struct",
+			inputSDK:       nil,
+			inputClusterID: "cluster-123",
+			inputRegion:    "br-sao-1",
+			expectedResult: FlattenedGetResult{},
+		},
+		{
+			name: "success: full data mapping",
+			inputSDK: &sdkK8s.NodePool{
+				ID:        "nodepool-uuid-123",
+				Name:      "my-nodepool",
+				CreatedAt: &testTime,
+				UpdatedAt: &testTime,
+				Replicas:  3,
+				AutoScale: &sdkK8s.AutoScale{
+					MinReplicas: &minReplicas,
+					MaxReplicas: &maxReplicas,
+				},
+				InstanceTemplate: sdkK8s.InstanceTemplate{
+					DiskSize:  50,
+					DiskType:  "premium",
+					NodeImage: "ubuntu-22.04",
+					Flavor: sdkK8s.Flavor{
+						ID:   "flavor-id-abc",
+						Name: "c1.medium",
+						RAM:  4096,
+						Size: 50,
+						VCPU: 2,
+					},
+				},
+				Labels:            map[string]string{"env": "prod", "tier": "frontend"},
+				SecurityGroups:    &[]string{"sg-1", "sg-2"},
+				Status:            sdkK8s.Status{State: "ACTIVE", Messages: []string{"Nodepool is active"}},
+				Taints:            &[]sdkK8s.Taint{{Effect: "NoSchedule", Key: "app", Value: "critical"}},
+				Zone:              &[]string{"zone-a"},
+				AvailabilityZones: &[]string{"a"},
+				MaxPodsPerNode:    &maxPods,
+			},
+			inputClusterID: "cluster-abc",
+			inputRegion:    "br-sao-1",
+			expectedResult: FlattenedGetResult{
+				ID:                         types.StringValue("nodepool-uuid-123"),
+				ClusterID:                  types.StringValue("cluster-abc"),
+				Name:                       types.StringValue("my-nodepool"),
+				CreatedAt:                  types.StringValue(testTimeString),
+				UpdatedAt:                  types.StringValue(testTimeString),
+				Replicas:                   types.Int64Value(3),
+				AutoScaleMaxReplicas:       types.Int64Value(5),
+				AutoScaleMinReplicas:       types.Int64Value(1),
+				InstanceTemplateDiskSize:   types.Int64Value(50),
+				InstanceTemplateDiskType:   types.StringValue("premium"),
+				InstanceTemplateNodeImage:  types.StringValue("ubuntu-22.04"),
+				InstanceTemplateFlavorID:   types.StringValue("flavor-id-abc"),
+				InstanceTemplateFlavorName: types.StringValue("c1.medium"),
+				InstanceTemplateFlavorRam:  types.Int64Value(4096),
+				InstanceTemplateFlavorSize: types.Int64Value(50),
+				InstanceTemplateFlavorVcpu: types.Int64Value(2),
+				Labels:                     expectedLabels,
+				SecurityGroups:             []types.String{types.StringValue("sg-1"), types.StringValue("sg-2")},
+				StatusState:                types.StringValue("ACTIVE"),
+				StatusMessages:             []types.String{types.StringValue("Nodepool is active")},
+				Taints:                     []tfutil.Taint{{Effect: types.StringValue("NoSchedule"), Key: types.StringValue("app"), Value: types.StringValue("critical")}},
+				Zone:                       []types.String{types.StringValue("zone-a")},
+				AvailabilityZones:          []types.String{types.StringValue("br-sao-1-a")},
+				MaxPodsPerNode:             types.Int64Value(110),
+			},
+		},
+		{
+			name: "success: minimal data with nils and empty slices",
+			inputSDK: &sdkK8s.NodePool{
+				ID:                "nodepool-uuid-456",
+				Name:              "minimal-nodepool",
+				CreatedAt:         nil,
+				UpdatedAt:         nil,
+				Replicas:          1,
+				AutoScale:         nil,
+				InstanceTemplate:  sdkK8s.InstanceTemplate{},
+				Labels:            map[string]string{},
+				SecurityGroups:    &[]string{},
+				Status:            sdkK8s.Status{State: "CREATING", Messages: []string{}},
+				Taints:            &[]sdkK8s.Taint{},
+				Zone:              &[]string{},
+				AvailabilityZones: &[]string{},
+				MaxPodsPerNode:    &maxPods,
+			},
+			inputClusterID: "cluster-def",
+			inputRegion:    "br-sao-1",
+			expectedResult: FlattenedGetResult{
+				ID:                         types.StringValue("nodepool-uuid-456"),
+				ClusterID:                  types.StringValue("cluster-def"),
+				Name:                       types.StringValue("minimal-nodepool"),
+				CreatedAt:                  types.StringNull(),
+				UpdatedAt:                  types.StringNull(),
+				Replicas:                   types.Int64Value(1),
+				AutoScaleMaxReplicas:       types.Int64Null(),
+				AutoScaleMinReplicas:       types.Int64Null(),
+				InstanceTemplateDiskSize:   types.Int64Value(0),
+				InstanceTemplateDiskType:   basetypes.NewStringValue(""),
+				InstanceTemplateNodeImage:  basetypes.NewStringValue(""),
+				InstanceTemplateFlavorID:   basetypes.NewStringValue(""),
+				InstanceTemplateFlavorName: basetypes.NewStringValue(""),
+				InstanceTemplateFlavorRam:  types.Int64Value(0),
+				InstanceTemplateFlavorSize: types.Int64Value(0),
+				InstanceTemplateFlavorVcpu: types.Int64Value(0),
+				Labels:                     expectedEmptyLabels,
+				SecurityGroups:             nil,
+				StatusState:                types.StringValue("CREATING"),
+				StatusMessages:             []types.String{types.StringNull()},
+				Taints:                     nil,
+				Zone:                       nil,
+				AvailabilityZones:          nil,
+				MaxPodsPerNode:             types.Int64Value(110),
+			},
+		},
+		{
+			name: "BUG: panics on nil MaxPodsPerNode",
+			inputSDK: &sdkK8s.NodePool{
+				ID:             "nodepool-uuid-789",
+				MaxPodsPerNode: nil,
+			},
+			expectPanic: true,
+		},
+		{
+			name: "BUG: panics on StatusMessages slice with more than 1 item",
+			inputSDK: &sdkK8s.NodePool{
+				ID:             "nodepool-uuid-101",
+				Status:         sdkK8s.Status{Messages: []string{"msg1", "msg2"}},
+				MaxPodsPerNode: &maxPods,
+			},
+			expectPanic: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if tc.expectPanic {
+					if r == nil {
+						t.Errorf("Expected a panic, but did not get one")
+					}
+				} else {
+					if r != nil {
+						t.Errorf("Did not expect a panic, but got one: %v", r)
+					}
+				}
+			}()
+
+			flattened, err := ConvertGetResultToFlattened(ctx, tc.inputSDK, tc.inputClusterID, tc.inputRegion)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if tc.expectPanic {
+				return
+			}
+
+			if !reflect.DeepEqual(flattened, tc.expectedResult) {
+				t.Errorf("Result does not match expected value.\nGot: %#v\nWant: %#v", flattened, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/mgc/resources/mgc_k8s_nodepool_test.go
+++ b/mgc/resources/mgc_k8s_nodepool_test.go
@@ -1,0 +1,165 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	k8sSDK "github.com/MagaluCloud/mgc-sdk-go/kubernetes"
+	"github.com/MagaluCloud/terraform-provider-mgc/mgc/tfutil"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockNodePoolService struct {
+	k8sSDK.NodePoolService
+	GetFunc func(ctx context.Context, clusterID, nodepoolID string) (*k8sSDK.NodePool, error)
+}
+
+func (m *mockNodePoolService) Get(ctx context.Context, clusterID, nodepoolID string) (*k8sSDK.NodePool, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, clusterID, nodepoolID)
+	}
+	return nil, errors.New("GetFunc is not implemented")
+}
+
+func TestWaitNodePoolState(t *testing.T) {
+	ctx := context.Background()
+	testTimeout := 100 * time.Millisecond
+	testInterval := 10 * time.Millisecond
+
+	t.Run("should return nil when nodepool is in desired state on first check", func(t *testing.T) {
+		mockSvc := &mockNodePoolService{
+			GetFunc: func(ctx context.Context, clusterID, nodepoolID string) (*k8sSDK.NodePool, error) {
+				return &k8sSDK.NodePool{
+					Status: k8sSDK.Status{State: NodepoolRunningState},
+				}, nil
+			},
+		}
+		r := &NewNodePoolResource{sdkNodepool: mockSvc}
+
+		err := r.waitNodePoolState(ctx, "np-id", "cluster-id", NodepoolRunningState, testTimeout, testInterval)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return nil after a few retries", func(t *testing.T) {
+		callCount := 0
+		mockSvc := &mockNodePoolService{
+			GetFunc: func(ctx context.Context, clusterID, nodepoolID string) (*k8sSDK.NodePool, error) {
+				callCount++
+				if callCount < 3 {
+					return &k8sSDK.NodePool{
+						Status: k8sSDK.Status{State: "Provisioning"},
+					}, nil
+				}
+				return &k8sSDK.NodePool{
+					Status: k8sSDK.Status{State: NodepoolRunningState},
+				}, nil
+			},
+		}
+		r := &NewNodePoolResource{sdkNodepool: mockSvc}
+
+		err := r.waitNodePoolState(ctx, "np-id", "cluster-id", NodepoolRunningState, testTimeout, testInterval)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return timeout error when state is never reached", func(t *testing.T) {
+		mockSvc := &mockNodePoolService{
+			GetFunc: func(ctx context.Context, clusterID, nodepoolID string) (*k8sSDK.NodePool, error) {
+				return &k8sSDK.NodePool{
+					Status: k8sSDK.Status{State: "Provisioning"},
+				}, nil
+			},
+		}
+		r := &NewNodePoolResource{sdkNodepool: mockSvc}
+
+		err := r.waitNodePoolState(ctx, "np-id", "cluster-id", NodepoolRunningState, testTimeout, testInterval)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "timeout waiting for node pool creation")
+	})
+
+	t.Run("should return error from the SDK get call", func(t *testing.T) {
+		expectedErr := errors.New("sdk error")
+		mockSvc := &mockNodePoolService{
+			GetFunc: func(ctx context.Context, clusterID, nodepoolID string) (*k8sSDK.NodePool, error) {
+				return nil, expectedErr
+			},
+		}
+		r := &NewNodePoolResource{sdkNodepool: mockSvc}
+
+		err := r.waitNodePoolState(ctx, "np-id", "cluster-id", NodepoolRunningState, testTimeout, testInterval)
+		assert.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+	})
+}
+
+func TestConvertStringArrayTFToSliceString(t *testing.T) {
+	t.Run("should return nil for nil input", func(t *testing.T) {
+		var input *[]types.String
+		result := convertStringArrayTFToSliceString(input)
+		assert.Nil(t, result)
+	})
+
+	t.Run("should return empty slice for empty slice input", func(t *testing.T) {
+		input := &[]types.String{}
+		result := convertStringArrayTFToSliceString(input)
+		assert.NotNil(t, result)
+		assert.Empty(t, *result)
+	})
+
+	t.Run("should convert slice with values correctly", func(t *testing.T) {
+		input := &[]types.String{
+			types.StringValue("az-1"),
+			types.StringValue("az-2"),
+			types.StringValue("az-3"),
+		}
+		expected := &[]string{"az-1", "az-2", "az-3"}
+		result := convertStringArrayTFToSliceString(input)
+		assert.Equal(t, expected, result)
+	})
+}
+
+func TestConvertTaintsNP(t *testing.T) {
+	t.Run("should return nil for nil input", func(t *testing.T) {
+		var input *[]tfutil.Taint
+		result := convertTaintsNP(input)
+		assert.Nil(t, result)
+	})
+
+	t.Run("should return empty slice for empty slice input", func(t *testing.T) {
+		input := &[]tfutil.Taint{}
+		result := convertTaintsNP(input)
+		assert.NotNil(t, result)
+		assert.Empty(t, *result)
+	})
+
+	t.Run("should convert slice with taints correctly", func(t *testing.T) {
+		input := &[]tfutil.Taint{
+			{
+				Effect: types.StringValue("NoSchedule"),
+				Key:    types.StringValue("key1"),
+				Value:  types.StringValue("value1"),
+			},
+			{
+				Effect: types.StringValue("PreferNoSchedule"),
+				Key:    types.StringValue("key2"),
+				Value:  types.StringValue("value2"),
+			},
+		}
+		expected := &[]k8sSDK.Taint{
+			{
+				Effect: "NoSchedule",
+				Key:    "key1",
+				Value:  "value1",
+			},
+			{
+				Effect: "PreferNoSchedule",
+				Key:    "key2",
+				Value:  "value2",
+			},
+		}
+		result := convertTaintsNP(input)
+		assert.Equal(t, expected, result)
+	})
+}

--- a/mgc/tfutil/mgc_k8s_common_test.go
+++ b/mgc/tfutil/mgc_k8s_common_test.go
@@ -1,0 +1,141 @@
+package tfutil
+
+import (
+	"testing"
+	"time"
+
+	k8sSDK "github.com/MagaluCloud/mgc-sdk-go/kubernetes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func pointer[T any](v T) *T {
+	return &v
+}
+
+func TestConvertToNodePoolToTFModel(t *testing.T) {
+	now := time.Now()
+	nowStr := ConvertTimeToRFC3339(&now)
+
+	testCases := []struct {
+		name     string
+		region   string
+		input    *k8sSDK.NodePool
+		expected NodePool
+	}{
+		{
+			name:     "should return empty struct when input is nil",
+			region:   "br-sao-1",
+			input:    nil,
+			expected: NodePool{},
+		},
+		{
+			name:   "should convert a fully populated node pool",
+			region: "br-sao-1",
+			input: &k8sSDK.NodePool{
+				ID:        "np-12345",
+				Name:      "my-full-nodepool",
+				Replicas:  3,
+				CreatedAt: &now,
+				UpdatedAt: &now,
+				AutoScale: &k8sSDK.AutoScale{
+					MaxReplicas: pointer(5),
+					MinReplicas: pointer(2),
+				},
+				InstanceTemplate: k8sSDK.InstanceTemplate{
+					Flavor: k8sSDK.Flavor{Name: "c1.medium"},
+				},
+				Taints: &[]k8sSDK.Taint{
+					{Key: "app", Value: "blue", Effect: "NoSchedule"},
+					{Key: "storage", Value: "ssd", Effect: "NoExecute"},
+				},
+				MaxPodsPerNode:    pointer(110),
+				AvailabilityZones: &[]string{"a", "b"},
+			},
+			expected: NodePool{
+				ID:          types.StringValue("np-12345"),
+				Name:        types.StringValue("my-full-nodepool"),
+				Flavor:      types.StringValue("c1.medium"),
+				Replicas:    types.Int64Value(3),
+				MaxReplicas: types.Int64Value(5),
+				MinReplicas: types.Int64Value(2),
+				CreatedAt:   types.StringPointerValue(nowStr),
+				UpdatedAt:   types.StringPointerValue(nowStr),
+				Taints: &[]Taint{
+					{Key: types.StringValue("app"), Value: types.StringValue("blue"), Effect: types.StringValue("NoSchedule")},
+					{Key: types.StringValue("storage"), Value: types.StringValue("ssd"), Effect: types.StringValue("NoExecute")},
+				},
+				MaxPodsPerNode: types.Int64Value(110),
+				AvailabilityZones: &[]types.String{
+					types.StringValue("br-sao-1-a"),
+					types.StringValue("br-sao-1-b"),
+				},
+			},
+		},
+		{
+			name:   "should handle partially populated node pool with nil values",
+			region: "us-east-1",
+			input: &k8sSDK.NodePool{
+				ID:        "np-67890",
+				Name:      "my-partial-nodepool",
+				Replicas:  1,
+				CreatedAt: &now,
+				UpdatedAt: nil,
+				AutoScale: &k8sSDK.AutoScale{
+					MaxReplicas: nil,
+					MinReplicas: pointer(1),
+				},
+				InstanceTemplate: k8sSDK.InstanceTemplate{
+					Flavor: k8sSDK.Flavor{Name: "t2.micro"},
+				},
+				Taints:            nil,
+				MaxPodsPerNode:    nil,
+				AvailabilityZones: nil,
+			},
+			expected: NodePool{
+				ID:                types.StringValue("np-67890"),
+				Name:              types.StringValue("my-partial-nodepool"),
+				Flavor:            types.StringValue("t2.micro"),
+				Replicas:          types.Int64Value(1),
+				MinReplicas:       types.Int64Value(1),
+				CreatedAt:         types.StringPointerValue(nowStr),
+				UpdatedAt:         types.StringNull(),
+				MaxReplicas:       types.Int64Null(),
+				Taints:            nil,
+				MaxPodsPerNode:    types.Int64Null(),
+				AvailabilityZones: nil,
+			},
+		},
+		{
+			name:   "should handle empty slices for taints and availability zones",
+			region: "br-sao-1",
+			input: &k8sSDK.NodePool{
+				ID:                "np-abcde",
+				Name:              "empty-slice-pool",
+				Replicas:          1,
+				Taints:            &[]k8sSDK.Taint{},
+				AvailabilityZones: &[]string{},
+			},
+			expected: NodePool{
+				ID:                types.StringValue("np-abcde"),
+				Name:              types.StringValue("empty-slice-pool"),
+				Replicas:          types.Int64Value(1),
+				Flavor:            types.StringNull(),
+				CreatedAt:         types.StringNull(),
+				UpdatedAt:         types.StringNull(),
+				MaxReplicas:       types.Int64Null(),
+				MinReplicas:       types.Int64Null(),
+				MaxPodsPerNode:    types.Int64Null(),
+				Taints:            &[]Taint{},
+				AvailabilityZones: &[]types.String{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ConvertToNodePoolToTFModel(tc.input, tc.region)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds handling of the region parameter to ensure proper
conversion between internal zone formats (e.g. 'a') and user-facing
availability zone names (e.g. 'br-sao-1-a'). It also includes
comprehensive test coverage for the conversion functions.

<!-- Provide a clear and concise description of the changes -->

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
