### PR TITLE
fix: k8s nodepool now correct return computed field

### DIFF
--- a/mgc/kubernetes/resource_cluster.go
+++ b/mgc/kubernetes/resource_cluster.go
@@ -212,6 +212,8 @@ func (r *k8sClusterResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	data.EnabledServerGroup = types.BoolNull()
+
 	createdCluster, err := r.GetClusterPooling(ctx, cluster.ID, "running", "provisioned")
 	if err != nil {
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))

--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -147,6 +147,7 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 			"max_pods_per_node": schema.Int64Attribute{
 				Description: "Maximum number of pods per node.",
 				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
- Kubernetes nodepool field `max_pods_per_node` now correct returns as a computed field.

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
