### PR TITLE
fix: LBaaS backend targets now correct calculate hash when target_type is instance

### DIFF
--- a/mgc/lbaas/models_test.go
+++ b/mgc/lbaas/models_test.go
@@ -840,7 +840,7 @@ func TestLoadBalancerModel_ToTerraformNetworkResource(t *testing.T) {
 							{
 								Port:      types.Int64Value(8080),
 								NICID:     types.StringValue("nic-123"),
-								IPAddress: types.StringValue("192.168.1.10"),
+								IPAddress: types.StringNull(),
 							},
 						},
 					},
@@ -999,7 +999,7 @@ func TestLoadBalancerModel_ConvertACLsToSDK_EdgeCases(t *testing.T) {
 			name: "large slice of ACLs",
 			input: func() *[]ACLModel {
 				acls := make([]ACLModel, 100)
-				for i := 0; i < 100; i++ {
+				for i := range 100 {
 					acls[i] = ACLModel{
 						Action:         types.StringValue("ALLOW"),
 						Name:           types.StringValue(fmt.Sprintf("acl-%d", i)),
@@ -1012,7 +1012,7 @@ func TestLoadBalancerModel_ConvertACLsToSDK_EdgeCases(t *testing.T) {
 			}(),
 			expected: func() []lbSDK.CreateNetworkACLRequest {
 				acls := make([]lbSDK.CreateNetworkACLRequest, 100)
-				for i := 0; i < 100; i++ {
+				for i := range 100 {
 					acls[i] = lbSDK.CreateNetworkACLRequest{
 						Action:         lbSDK.AclActionType("ALLOW"),
 						Name:           stringPtr(fmt.Sprintf("acl-%d", i)),

--- a/mgc/lbaas/resource_network.go
+++ b/mgc/lbaas/resource_network.go
@@ -793,7 +793,7 @@ func (r *LoadBalancerResource) waitLoadBalancerState(ctx context.Context, lbID s
 				return nil, err
 			}
 			if lb.Status == lbSDK.LoadBalancerStatusFailed {
-				return nil, fmt.Errorf("load balancer %s is in error state", lbID)
+				return nil, fmt.Errorf("load balancer %s is in error state. %s", lbID, *lb.LastOperationStatus)
 			}
 			if lb.Status == desiredState {
 				return &lb, nil

--- a/mgc/lbaas/target_validator.go
+++ b/mgc/lbaas/target_validator.go
@@ -48,14 +48,14 @@ func (v TargetValidator) ValidateSet(ctx context.Context, req validator.SetReque
 		switch targetsTypeValue {
 		case "raw":
 			// For raw type: ip_address and port are required, nic_id must be empty
-			if target.IPAddress.IsNull() || target.IPAddress.IsUnknown() || target.IPAddress.ValueString() == "" {
+			if !target.IPAddress.IsUnknown() && (target.IPAddress.IsNull() || target.IPAddress.ValueString() == "") {
 				resp.Diagnostics.AddAttributeError(
 					targetPath.AtName("ip_address"),
 					"Missing Required Attribute",
 					"ip_address is required when targets_type is 'raw'",
 				)
 			}
-			if !target.NICID.IsNull() && !target.NICID.IsUnknown() && target.NICID.ValueString() != "" {
+			if !target.NICID.IsUnknown() && !target.NICID.IsNull() && target.NICID.ValueString() != "" {
 				resp.Diagnostics.AddAttributeError(
 					targetPath.AtName("nic_id"),
 					"Invalid Attribute",
@@ -64,14 +64,14 @@ func (v TargetValidator) ValidateSet(ctx context.Context, req validator.SetReque
 			}
 		case "instance":
 			// For instance type: nic_id and port are required, ip_address must be empty
-			if target.NICID.IsNull() || target.NICID.IsUnknown() || target.NICID.ValueString() == "" {
+			if !target.NICID.IsUnknown() && (target.NICID.IsNull() || target.NICID.ValueString() == "") {
 				resp.Diagnostics.AddAttributeError(
 					targetPath.AtName("nic_id"),
 					"Missing Required Attribute",
 					"nic_id is required when targets_type is 'instance'",
 				)
 			}
-			if !target.IPAddress.IsNull() && !target.IPAddress.IsUnknown() && target.IPAddress.ValueString() != "" {
+			if !target.IPAddress.IsUnknown() && !target.IPAddress.IsNull() && target.IPAddress.ValueString() != "" {
 				resp.Diagnostics.AddAttributeError(
 					targetPath.AtName("ip_address"),
 					"Invalid Attribute",
@@ -97,13 +97,16 @@ func validateTLSCertNameForProtocol(protocol types.String, val types.String) (st
 	if protocol.IsNull() || protocol.IsUnknown() || protocol.ValueString() == "" {
 		return "", "", false
 	}
+	if val.IsUnknown() {
+		return "", "", false
+	}
 	switch protocol.ValueString() {
 	case "tcp":
-		if !val.IsNull() && !val.IsUnknown() && val.ValueString() != "" {
+		if !val.IsNull() && val.ValueString() != "" {
 			return "Value error", "tls_certificate_name should not be provided when protocol is 'tcp'", true
 		}
 	case "tls":
-		if val.IsNull() || val.IsUnknown() || val.ValueString() == "" {
+		if val.IsNull() || val.ValueString() == "" {
 			return "Missing Required Attribute", "tls_certificate_name must be provided when protocol is 'tls'", true
 		}
 	}

--- a/mgc/lbaas/target_validator_test.go
+++ b/mgc/lbaas/target_validator_test.go
@@ -7,9 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+	fwschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,8 +27,20 @@ func TestValidateTLSCertNameForProtocol_TCP_WithoutTLSName(t *testing.T) {
 	assert.False(t, has)
 }
 
+func TestValidateTLSCertNameForProtocol_TCP_WithEmptyTLSName(t *testing.T) {
+	_, _, has := validateTLSCertNameForProtocol(types.StringValue("tcp"), types.StringValue(""))
+	assert.False(t, has)
+}
+
 func TestValidateTLSCertNameForProtocol_TLS_WithoutTLSName(t *testing.T) {
 	summary, detail, has := validateTLSCertNameForProtocol(types.StringValue("tls"), types.StringNull())
+	assert.True(t, has)
+	assert.Equal(t, "Missing Required Attribute", summary)
+	assert.Equal(t, "tls_certificate_name must be provided when protocol is 'tls'", detail)
+}
+
+func TestValidateTLSCertNameForProtocol_TLS_WithEmptyTLSName(t *testing.T) {
+	summary, detail, has := validateTLSCertNameForProtocol(types.StringValue("tls"), types.StringValue(""))
 	assert.True(t, has)
 	assert.Equal(t, "Missing Required Attribute", summary)
 	assert.Equal(t, "tls_certificate_name must be provided when protocol is 'tls'", detail)
@@ -48,12 +62,66 @@ func TestValidateTLSCertNameForProtocol_UnknownProtocol(t *testing.T) {
 	assert.False(t, has)
 }
 
-func makeConfig(t *testing.T, targetsType string) tfsdk.Config {
-	return tfsdk.Config{}
+func TestValidateTLSCertNameForProtocol_UnknownValue(t *testing.T) {
+	_, _, has := validateTLSCertNameForProtocol(types.StringValue("tcp"), types.StringUnknown())
+	assert.False(t, has)
+
+	_, _, has = validateTLSCertNameForProtocol(types.StringValue("tls"), types.StringUnknown())
+	assert.False(t, has)
 }
 
 func runTargetValidator(t *testing.T, targetsType string, set types.Set) diag.Diagnostics {
-	cfg := makeConfig(t, targetsType)
+	testSchema := fwschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"targets_type": fwschema.StringAttribute{
+				Optional: true,
+			},
+			"targets": fwschema.SetNestedAttribute{
+				NestedObject: fwschema.NestedAttributeObject{
+					Attributes: map[string]fwschema.Attribute{
+						"nic_id": fwschema.StringAttribute{
+							Optional: true,
+						},
+						"ip_address": fwschema.StringAttribute{
+							Optional: true,
+						},
+						"port": fwschema.Int64Attribute{
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	targetObjectType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"nic_id":     tftypes.String,
+			"ip_address": tftypes.String,
+			"port":       tftypes.Number,
+		},
+	}
+
+	rawValue := tftypes.NewValue(
+		tftypes.Object{
+			AttributeTypes: map[string]tftypes.Type{
+				"targets_type": tftypes.String,
+				"targets": tftypes.Set{
+					ElementType: targetObjectType,
+				},
+			},
+		},
+		map[string]tftypes.Value{
+			"targets_type": tftypes.NewValue(tftypes.String, targetsType),
+			"targets":      tftypes.NewValue(tftypes.Set{ElementType: targetObjectType}, nil),
+		},
+	)
+
+	cfg := tfsdk.Config{
+		Schema: testSchema,
+		Raw:    rawValue,
+	}
+
 	req := validator.SetRequest{
 		Path:        path.Root("targets"),
 		Config:      cfg,
@@ -77,7 +145,87 @@ func TestTargetValidator_UnknownSet_NoDiagnostics(t *testing.T) {
 	assert.False(t, diags.HasError())
 }
 
-func TestTargetValidator_RawType_MissingIPAddress(t *testing.T) {
+func TestTargetValidator_RawType_UnknownIPAddress_NoDiagnostics(t *testing.T) {
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}}
+	elem, _ := types.ObjectValue(map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}, map[string]attr.Value{
+		"nic_id":     types.StringNull(),
+		"ip_address": types.StringUnknown(),
+		"port":       types.Int64Value(80),
+	})
+	set := types.SetValueMust(elementType, []attr.Value{elem})
+	diags := runTargetValidator(t, "raw", set)
+	assert.False(t, diags.HasError())
+}
+
+func TestTargetValidator_RawType_UnknownNICID_NoDiagnostics(t *testing.T) {
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}}
+	elem, _ := types.ObjectValue(map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}, map[string]attr.Value{
+		"nic_id":     types.StringUnknown(),
+		"ip_address": types.StringValue("10.0.0.1"),
+		"port":       types.Int64Value(80),
+	})
+	set := types.SetValueMust(elementType, []attr.Value{elem})
+	diags := runTargetValidator(t, "raw", set)
+	assert.False(t, diags.HasError())
+}
+
+func TestTargetValidator_InstanceType_UnknownNICID_NoDiagnostics(t *testing.T) {
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}}
+	elem, _ := types.ObjectValue(map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}, map[string]attr.Value{
+		"nic_id":     types.StringUnknown(),
+		"ip_address": types.StringNull(),
+		"port":       types.Int64Value(443),
+	})
+	set := types.SetValueMust(elementType, []attr.Value{elem})
+	diags := runTargetValidator(t, "instance", set)
+	assert.False(t, diags.HasError())
+}
+
+func TestTargetValidator_InstanceType_UnknownIPAddress_NoDiagnostics(t *testing.T) {
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}}
+	elem, _ := types.ObjectValue(map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}, map[string]attr.Value{
+		"nic_id":     types.StringValue("nic-1"),
+		"ip_address": types.StringUnknown(),
+		"port":       types.Int64Value(8080),
+	})
+	set := types.SetValueMust(elementType, []attr.Value{elem})
+	diags := runTargetValidator(t, "instance", set)
+	assert.False(t, diags.HasError())
+}
+
+func TestTargetValidator_RawType_MissingIPAddress_HasError(t *testing.T) {
 	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
 		"nic_id":     types.StringType,
 		"ip_address": types.StringType,
@@ -94,10 +242,33 @@ func TestTargetValidator_RawType_MissingIPAddress(t *testing.T) {
 	})
 	set := types.SetValueMust(elementType, []attr.Value{elem})
 	diags := runTargetValidator(t, "raw", set)
-	assert.False(t, diags.HasError())
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Summary(), "Missing Required Attribute")
+	assert.Contains(t, diags[0].Detail(), "ip_address is required when targets_type is 'raw'")
 }
 
-func TestTargetValidator_RawType_WithNICIDInvalid(t *testing.T) {
+func TestTargetValidator_RawType_EmptyIPAddress_HasError(t *testing.T) {
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}}
+	elem, _ := types.ObjectValue(map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}, map[string]attr.Value{
+		"nic_id":     types.StringNull(),
+		"ip_address": types.StringValue(""),
+		"port":       types.Int64Value(80),
+	})
+	set := types.SetValueMust(elementType, []attr.Value{elem})
+	diags := runTargetValidator(t, "raw", set)
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Summary(), "Missing Required Attribute")
+}
+
+func TestTargetValidator_RawType_WithNICID_HasError(t *testing.T) {
 	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
 		"nic_id":     types.StringType,
 		"ip_address": types.StringType,
@@ -114,10 +285,32 @@ func TestTargetValidator_RawType_WithNICIDInvalid(t *testing.T) {
 	})
 	set := types.SetValueMust(elementType, []attr.Value{elem})
 	diags := runTargetValidator(t, "raw", set)
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Summary(), "Invalid Attribute")
+	assert.Contains(t, diags[0].Detail(), "nic_id must be empty when targets_type is 'raw'")
+}
+
+func TestTargetValidator_RawType_Valid_NoError(t *testing.T) {
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}}
+	elem, _ := types.ObjectValue(map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}, map[string]attr.Value{
+		"nic_id":     types.StringNull(),
+		"ip_address": types.StringValue("10.0.0.1"),
+		"port":       types.Int64Value(80),
+	})
+	set := types.SetValueMust(elementType, []attr.Value{elem})
+	diags := runTargetValidator(t, "raw", set)
 	assert.False(t, diags.HasError())
 }
 
-func TestTargetValidator_InstanceType_MissingNICID(t *testing.T) {
+func TestTargetValidator_InstanceType_MissingNICID_HasError(t *testing.T) {
 	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
 		"nic_id":     types.StringType,
 		"ip_address": types.StringType,
@@ -134,10 +327,33 @@ func TestTargetValidator_InstanceType_MissingNICID(t *testing.T) {
 	})
 	set := types.SetValueMust(elementType, []attr.Value{elem})
 	diags := runTargetValidator(t, "instance", set)
-	assert.False(t, diags.HasError())
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Summary(), "Missing Required Attribute")
+	assert.Contains(t, diags[0].Detail(), "nic_id is required when targets_type is 'instance'")
 }
 
-func TestTargetValidator_InstanceType_WithIPAddressInvalid(t *testing.T) {
+func TestTargetValidator_InstanceType_EmptyNICID_HasError(t *testing.T) {
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}}
+	elem, _ := types.ObjectValue(map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}, map[string]attr.Value{
+		"nic_id":     types.StringValue(""),
+		"ip_address": types.StringNull(),
+		"port":       types.Int64Value(443),
+	})
+	set := types.SetValueMust(elementType, []attr.Value{elem})
+	diags := runTargetValidator(t, "instance", set)
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Summary(), "Missing Required Attribute")
+}
+
+func TestTargetValidator_InstanceType_WithIPAddress_HasError(t *testing.T) {
 	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
 		"nic_id":     types.StringType,
 		"ip_address": types.StringType,
@@ -150,6 +366,28 @@ func TestTargetValidator_InstanceType_WithIPAddressInvalid(t *testing.T) {
 	}, map[string]attr.Value{
 		"nic_id":     types.StringValue("nic-1"),
 		"ip_address": types.StringValue("10.0.0.2"),
+		"port":       types.Int64Value(8080),
+	})
+	set := types.SetValueMust(elementType, []attr.Value{elem})
+	diags := runTargetValidator(t, "instance", set)
+	assert.True(t, diags.HasError())
+	assert.Contains(t, diags[0].Summary(), "Invalid Attribute")
+	assert.Contains(t, diags[0].Detail(), "ip_address must be empty when targets_type is 'instance'")
+}
+
+func TestTargetValidator_InstanceType_Valid_NoError(t *testing.T) {
+	elementType := types.ObjectType{AttrTypes: map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}}
+	elem, _ := types.ObjectValue(map[string]attr.Type{
+		"nic_id":     types.StringType,
+		"ip_address": types.StringType,
+		"port":       types.Int64Type,
+	}, map[string]attr.Value{
+		"nic_id":     types.StringValue("nic-1"),
+		"ip_address": types.StringNull(),
 		"port":       types.Int64Value(8080),
 	})
 	set := types.SetValueMust(elementType, []attr.Value{elem})


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
- Fixed target validator to properly handle Terraform's unknown values during plan phase, preventing premature validation errors
- Fixed `ToTerraformNetworkResource` to correctly set null values based on `targets_type` (sets `ip_address` to null for "instance" type and `nic_id` to null for "raw" type)
- Minor code style improvements (replaced loop counters with range syntax)

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
