### PR TITLE
feat: base64 validation for VM instance user_data

### DIFF
--- a/docs/resources/virtual_machine_instances.md
+++ b/docs/resources/virtual_machine_instances.md
@@ -96,7 +96,7 @@ This attribute can only be used when "network_interface_id" is not set.
 			 If "snapshot_id" is provided, the snapshot will be used instead of an image.
 - `snapshot_id` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The snapshot ID used to create the virtual machine instance. If set, the snapshot will be used instead of an image.
 - `ssh_key_name` (String) The name of the SSH key associated with the virtual machine instance. Not required for Windows instances.
-- `user_data` (String) User data for instance initialization.
+- `user_data` (String) User data for instance initialization (encoded in base64).
 - `vpc_id` (String) The VPC ID where the primary network interface will be created.
 
 ### Read-Only

--- a/mgc/virtualmachines/resource_instances.go
+++ b/mgc/virtualmachines/resource_instances.go
@@ -219,8 +219,14 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"user_data": schema.StringAttribute{
-				Description: "User data for instance initialization.",
+				Description: "User data for instance initialization (encoded in base64).",
 				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[A-Za-z0-9+/]*={0,2}$`),
+						"The user data must be encoded in base64. You can use Terraform's builtin base64encode() for that.",
+					),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},


### PR DESCRIPTION
## What does this PR do?
Improve documentation and make sure user_data in VM instance is indeed base64-encoded.

## How Has This Been Tested?
Maual testing, passing both encoded and unencoded user_data

```
$ terraform apply
╷
│ Error: Invalid Attribute Value Match
│ 
│   with mgc_virtual_machine_instances.instance_with_usardata,
│   on main.tf line 20, in resource "mgc_virtual_machine_instances" "instance_with_usardata":
│   20:   user_data    = "#!/bin/bash\necho 'Hello, World!'"
│ 
│ Attribute user_data The user data must be encoded in base64. You can use Terraform's builtin base64encode() for that., got: #!/bin/bash
│ echo 'Hello, World!'
╵

```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
