### PR TITLE
feat: add creating_error_capacity as a fail state on VM instance create

### DIFF
--- a/mgc/virtualmachines/resource_instances.go
+++ b/mgc/virtualmachines/resource_instances.go
@@ -39,6 +39,7 @@ var imageExpands []computeSdk.InstanceExpand = []computeSdk.InstanceExpand{compu
 var errorStatus = []InstanceStatus{
 	StatusCreatingError,
 	StatusCreatingNetworkError,
+	StatusCreatingErrorCapacity,
 	StatusCreatingErrorQuota,
 	StatusCreatingErrorQuotaRam,
 	StatusCreatingErrorQuotaVcpu,
@@ -61,6 +62,7 @@ const (
 	StatusProvisioning                 InstanceStatus = "provisioning"
 	StatusCreating                     InstanceStatus = "creating"
 	StatusCreatingError                InstanceStatus = "creating_error"
+	StatusCreatingErrorCapacity        InstanceStatus = "creating_error_capacity"
 	StatusCreatingNetworkError         InstanceStatus = "creating_network_error"
 	StatusCreatingErrorQuota           InstanceStatus = "creating_error_quota"
 	StatusCreatingErrorQuotaRam        InstanceStatus = "creating_error_quota_ram"

--- a/mgc/virtualmachines/resource_instances_test.go
+++ b/mgc/virtualmachines/resource_instances_test.go
@@ -271,8 +271,18 @@ func TestInstanceStatusList_ContainsExpectedErrors(t *testing.T) {
 	expectedErrors := []InstanceStatus{
 		StatusCreatingError,
 		StatusCreatingNetworkError,
+		StatusCreatingErrorCapacity,
 		StatusCreatingErrorQuota,
+		StatusCreatingErrorQuotaRam,
+		StatusCreatingErrorQuotaVcpu,
+		StatusCreatingErrorQuotaDisk,
+		StatusCreatingErrorQuotaInstance,
+		StatusCreatingErrorQuotaFloatingIP,
+		StatusCreatingErrorQuotaNetwork,
 		StatusRetypingError,
+		StatusRetypingErrorQuotaRam,
+		StatusRetypingErrorQuotaVcpu,
+		StatusRetypingErrorQuota,
 		StatusDeletingError,
 	}
 


### PR DESCRIPTION
## What does this PR do?
Considers `creating_error_capacity` as an failed end-state on VM instance creation.
Without it, when reaching this state, the provider will wait until timeout.

## How Has This Been Tested?
Manual testing on VM creation with very large requirements:
TODO

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
