### PR TITLE
fix: resize DBaaS instance without recreate

### DIFF
--- a/mgc/database/resource_instances.go
+++ b/mgc/database/resource_instances.go
@@ -249,6 +249,7 @@ func (r *DBaaSInstanceResource) Schema(_ context.Context, _ resource.SchemaReque
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"availability_zone": schema.StringAttribute{
@@ -260,6 +261,7 @@ func (r *DBaaSInstanceResource) Schema(_ context.Context, _ resource.SchemaReque
 				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"status": schema.StringAttribute{


### PR DESCRIPTION
## What does this PR do?
- Added `stringplanmodifier.UseStateForUnknown()` to the `parameter_group` and `availability_zone` attributes so that it doesn't force recreation when no value is provided for them.

## How Has This Been Tested?
Manual: making changes to the .tf file to check the results using terraform plan and terraform apply.

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
