### PR TITLE
fix: update import state logic to set attributes directly in k8s

### DIFF
--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -355,12 +356,13 @@ func (r *NewNodePoolResource) ImportState(ctx context.Context, req resource.Impo
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &NodePoolResourceModel{
-		ClusterID: types.StringValue(ids[0]),
-		NodePool: NodePool{
-			ID: types.StringValue(ids[1]),
-		},
-	})...)
+	resp.Diagnostics.Append(
+		resp.State.SetAttribute(ctx, path.Root("cluster_id"), ids[0])...,
+	)
+
+	resp.Diagnostics.Append(
+		resp.State.SetAttribute(ctx, path.Root("id"), ids[1])...,
+	)
 }
 
 func convertTaintsNP(taints *[]Taint) *[]k8sSDK.Taint {


### PR DESCRIPTION
## What does this PR do?
- Updated import state logic to set attributes directly in k8s

## How Has This Been Tested?
Manual: it was created a Kubernetes cluster and the node pool. Then the Terraform state file was deleted and they were imported again with `terraform import` and `tofu import`.

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
