### PR TITLE
feat: set default parameters for bucket functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MagaluCloud/terraform-provider-mgc
 go 1.25.3
 
 require (
-	github.com/MagaluCloud/mgc-sdk-go v1.1.0
+	github.com/MagaluCloud/mgc-sdk-go v1.3.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/MagaluCloud/mgc-sdk-go v1.0.0 h1:Zfpzy7OxbAmHdr3v4yvolEJ0OmAGN0r6L2Rs
 github.com/MagaluCloud/mgc-sdk-go v1.0.0/go.mod h1:kNVX4v1CBlkIcKxnzNcQ0jgs5Awu3Vk0Bd+vaG7GvUs=
 github.com/MagaluCloud/mgc-sdk-go v1.1.0 h1:DXWhOxpoHxoTUiYTJixDJcl55RhZbyk+cEXq0mJpEGc=
 github.com/MagaluCloud/mgc-sdk-go v1.1.0/go.mod h1:kNVX4v1CBlkIcKxnzNcQ0jgs5Awu3Vk0Bd+vaG7GvUs=
+github.com/MagaluCloud/mgc-sdk-go v1.3.0 h1:elhQ9Q+Xui4eADoGxQb4MZuxUA9gfY5FWCPbofuRt7Q=
+github.com/MagaluCloud/mgc-sdk-go v1.3.0/go.mod h1:kNVX4v1CBlkIcKxnzNcQ0jgs5Awu3Vk0Bd+vaG7GvUs=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/mgc/objects/datasource_buckets.go
+++ b/mgc/objects/datasource_buckets.go
@@ -70,7 +70,7 @@ func (d *objectStorageBucketsDataSource) Schema(ctx context.Context, req datasou
 func (d *objectStorageBucketsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data ObjectStorageBucketsDataSourceModel
 
-	buckets, err := d.buckets.List(ctx, objSdk.BucketListOptions{})
+	buckets, err := d.buckets.List(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error listing buckets",

--- a/mgc/objects/resource_buckets.go
+++ b/mgc/objects/resource_buckets.go
@@ -176,18 +176,18 @@ func (r *objectStorageBuckets) Create(ctx context.Context, req resource.CreateRe
 				"Error enabling versioning",
 				fmt.Sprintf("Could not enable versioning for bucket %s: %s", bucketName, err.Error()),
 			)
-			_ = r.buckets.Delete(ctx, bucketName)
+			_ = r.buckets.Delete(ctx, bucketName, false)
 			return
 		}
 	}
 
 	if !plan.Lock.IsNull() && plan.Lock.ValueBool() {
-		if err := r.buckets.LockBucket(ctx, bucketName); err != nil {
+		if err := r.buckets.LockBucket(ctx, bucketName, 1, "days"); err != nil {
 			resp.Diagnostics.AddError(
 				"Error locking bucket",
 				fmt.Sprintf("Could not enable object lock for bucket %s: %s", bucketName, err.Error()),
 			)
-			_ = r.buckets.Delete(ctx, bucketName)
+			_ = r.buckets.Delete(ctx, bucketName, false)
 			return
 		}
 	}
@@ -199,7 +199,7 @@ func (r *objectStorageBuckets) Create(ctx context.Context, req resource.CreateRe
 				"Error parsing bucket policy",
 				fmt.Sprintf("Could not parse bucket policy JSON: %s", err.Error()),
 			)
-			_ = r.buckets.Delete(ctx, bucketName)
+			_ = r.buckets.Delete(ctx, bucketName, false)
 			return
 		}
 
@@ -208,7 +208,7 @@ func (r *objectStorageBuckets) Create(ctx context.Context, req resource.CreateRe
 				"Error setting bucket policy",
 				fmt.Sprintf("Could not set bucket policy for %s: %s", bucketName, err.Error()),
 			)
-			_ = r.buckets.Delete(ctx, bucketName)
+			_ = r.buckets.Delete(ctx, bucketName, false)
 			return
 		}
 	}
@@ -221,7 +221,7 @@ func (r *objectStorageBuckets) Create(ctx context.Context, req resource.CreateRe
 		})
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
-			_ = r.buckets.Delete(ctx, bucketName)
+			_ = r.buckets.Delete(ctx, bucketName, false)
 			return
 		}
 
@@ -231,7 +231,7 @@ func (r *objectStorageBuckets) Create(ctx context.Context, req resource.CreateRe
 				"Error parsing CORS configuration",
 				fmt.Sprintf("Could not parse CORS configuration: %s", err.Error()),
 			)
-			_ = r.buckets.Delete(ctx, bucketName)
+			_ = r.buckets.Delete(ctx, bucketName, false)
 			return
 		}
 
@@ -240,7 +240,7 @@ func (r *objectStorageBuckets) Create(ctx context.Context, req resource.CreateRe
 				"Error setting CORS configuration",
 				fmt.Sprintf("Could not set CORS configuration for bucket %s: %s", bucketName, err.Error()),
 			)
-			_ = r.buckets.Delete(ctx, bucketName)
+			_ = r.buckets.Delete(ctx, bucketName, false)
 			return
 		}
 	} else if plan.CORS.IsUnknown() {
@@ -402,7 +402,7 @@ func (r *objectStorageBuckets) Update(ctx context.Context, req resource.UpdateRe
 
 	if !plan.Lock.Equal(state.Lock) {
 		if plan.Lock.ValueBool() {
-			if err := r.buckets.LockBucket(ctx, bucketName); err != nil {
+			if err := r.buckets.LockBucket(ctx, bucketName, 1, "days"); err != nil {
 				resp.Diagnostics.AddError(
 					"Error locking bucket",
 					fmt.Sprintf("Could not enable object lock for bucket %s: %s", bucketName, err.Error()),
@@ -528,7 +528,7 @@ func (r *objectStorageBuckets) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	if err := r.buckets.Delete(ctx, bucketName); err != nil {
+	if err := r.buckets.Delete(ctx, bucketName, false); err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting bucket",
 			fmt.Sprintf("Could not delete bucket %s: %s", bucketName, err.Error()),


### PR DESCRIPTION
## What does this PR do?
The SDK version has been updated and, as a result, new parameters were set in the functions.
The configured values match the behavior we previously had.

- `buckets.Delete()`: `recursive = false` (we did not support recursive deletion before)
- `buckets.LockBucket()`: `1 day` (this was the default value in the SDK)

## How Has This Been Tested?
A new bucket was created using Terraform. Lock and unlock logic was implemented for it. In addition, a listing of all buckets was added.

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
