### PR TITLE
fix: get engine and instance info

### DIFF
--- a/mgc/database/resource_clusters.go
+++ b/mgc/database/resource_clusters.go
@@ -395,6 +395,21 @@ func (r *DBaaSClusterResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	engineInfo, err := r.dbaasEngines.Get(ctx, detailedCluster.EngineID)
+	if err != nil {
+		resp.Diagnostics.AddError(utils.ParseSDKError(err))
+		return
+	}
+	state.EngineName = types.StringValue(engineInfo.Name)
+	state.EngineVersion = types.StringValue(engineInfo.Version)
+
+	instanceInfo, err := r.dbaasInstanceTypes.Get(ctx, detailedCluster.InstanceTypeID)
+	if err != nil {
+		resp.Diagnostics.AddError(utils.ParseSDKError(err))
+		return
+	}
+	state.InstanceType = types.StringValue(instanceInfo.Label)
+
 	r.populateModelFromDetailResponse(detailedCluster, &state)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }


### PR DESCRIPTION
## What does this PR do?
- Ajustado para pegar as informações da engine e instance no método `Read` para que essas informações sejam salvas ao realizar o `import` do cluster.

## How Has This Been Tested?
- Importado um cluster e verificado as informações no arquivo `.tfstate`
- Criado, deletado e atualizado um cluster para verificar se tudo está funcionando corretamente ainda

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
