### PR TITLE
Bugfix: remove replicas update on k8s nodepool update

### DIFF
--- a/docs/resources/kubernetes_nodepool.md
+++ b/docs/resources/kubernetes_nodepool.md
@@ -31,7 +31,7 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
 - `cluster_id` (String) UUID of the Kubernetes cluster.
 - `flavor_name` (String) Definition of the CPU, RAM, and storage capacity of the nodes.
 - `name` (String) Name of the node pool.
-- `replicas` (Number) Number of replicas of the nodes in the node pool.
+- `replicas` (Number) Initial number of replicas of the nodes in the node pool. Required at creation; after creation, changes to this value are ignored because the replica count is managed by the API (e.g. via autoscaling between min_replicas and max_replicas).
 
 ### Optional
 

--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -97,10 +97,13 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 				},
 			},
 			"replicas": schema.Int64Attribute{
-				Description: "Number of replicas of the nodes in the node pool.",
+				Description: "Initial number of replicas of the nodes in the node pool. Required at creation; after creation, changes to this value are ignored because the replica count is managed by the API (e.g. via autoscaling between min_replicas and max_replicas).",
 				Required:    true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(0),
+				},
+				PlanModifiers: []planmodifier.Int64{
+					utils.UseStateForInt64AfterCreate(),
 				},
 			},
 
@@ -292,10 +295,7 @@ func (r *NewNodePoolResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	repli := int(data.Replicas.ValueInt64())
-	updateParam := k8sSDK.PatchNodePoolRequest{
-		Replicas: &repli,
-	}
+	updateParam := k8sSDK.PatchNodePoolRequest{}
 
 	if !data.MaxReplicas.IsUnknown() || !data.MinReplicas.IsUnknown() {
 		updateParam.AutoScale = &k8sSDK.AutoScale{}

--- a/mgc/utils/planmodifiers.go
+++ b/mgc/utils/planmodifiers.go
@@ -150,6 +150,36 @@ func (m RequireReplacePlanModifier) PlanModifyString(ctx context.Context, req pl
 	}
 }
 
+type useStateForInt64AfterCreate struct{}
+
+// UseStateForInt64AfterCreate returns a planmodifier that preserves the state
+// value for an Int64 attribute after the resource has been created. Changes to
+// the attribute in configuration will not produce a plan diff. This is useful
+// when the attribute's value is managed by the API after creation (for
+// example, a replica count that is adjusted by an autoscaler), where the
+// config value is only meaningful at creation time.
+func UseStateForInt64AfterCreate() planmodifier.Int64 {
+	return useStateForInt64AfterCreate{}
+}
+
+func (m useStateForInt64AfterCreate) Description(_ context.Context) string {
+	return "Preserves the state value after resource creation; configuration changes to this attribute are ignored because its value is managed by the API."
+}
+
+func (m useStateForInt64AfterCreate) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m useStateForInt64AfterCreate) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	if req.StateValue.IsNull() {
+		return
+	}
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	resp.PlanValue = req.StateValue
+}
+
 type setRequiresReplaceOnChange struct{}
 
 // SetRequiresReplaceOnChange returns a planmodifier that requires resource replacement


### PR DESCRIPTION
## What does this PR do?

This pull request removes the `replicas` parameter from the Kubernetes node pool update, since the number of replicas in Kubernetes v3 clusters is neither mandatory nor recommended; the autoscaler should set it based on the workload.

## How Has This Been Tested?

Tested.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
