### PR TITLE
feat: suporte a subnet_ids customizados e upgrade in-place de versão

### DIFF
--- a/docs/data-sources/kubernetes_cluster.md
+++ b/docs/data-sources/kubernetes_cluster.md
@@ -29,13 +29,16 @@ output "cluster" {
 
 - `id` (String) Cluster's UUID.
 
+### Optional
+
+- `subnet_ids` (Set of String) List of subnet ids.
+
 ### Read-Only
 
 - `addons_loadbalance` (String) Flag indicating whether the load balancer service is enabled/disabled in the cluster.
 - `addons_secrets` (String) Native Kubernetes secret to be included in the cluster during provisioning.
 - `addons_volume` (String) Flag indicating whether the storage class service is configured by default.
 - `allowed_cidrs` (List of String) List of allowed CIDR blocks for API server access.
-- `cidr` (String) Available IP addresses used for provisioning nodes in the cluster.
 - `cluster_ipv4_cidr` (String) The IP address range of the Kubernetes cluster.
 - `controlplane` (Attributes) Object of the node pool response. (see [below for nested schema](#nestedatt--controlplane))
 - `created_at` (String) Creation date of the Kubernetes cluster.
@@ -49,13 +52,11 @@ output "cluster" {
 - `machine_types_source` (String) Source of machine types for the cluster.
 - `message` (String) Detailed message about the status of the cluster or node.
 - `name` (String) Kubernetes cluster name.
-- `network_name` (String) Name of the cluster network.
 - `node_pools` (Attributes List) An array representing a set of nodes within a Kubernetes cluster. (see [below for nested schema](#nestedatt--node_pools))
 - `platform_version` (String) Platform version of the cluster.
 - `region` (String) Identifier of the region where the Kubernetes cluster is located.
 - `services_ipv4_cidr` (String) The IP address range of the Kubernetes cluster service.
 - `state` (String) Current state of the cluster or node.
-- `subnet_id` (String) Identifier of the internal subnet where the cluster will be provisioned.
 - `updated_at` (String) Date of the last modification of the Kubernetes cluster.
 - `version` (String) The native Kubernetes version of the cluster.
 
@@ -96,6 +97,10 @@ Read-Only:
 <a id="nestedatt--node_pools"></a>
 ### Nested Schema for `node_pools`
 
+Optional:
+
+- `subnet_ids` (Set of String) List of subnet ids.
+
 Read-Only:
 
 - `availability_zones` (Set of String) List of availability zones where the nodes in the node pool are distributed.
@@ -111,6 +116,7 @@ Read-Only:
 - `security_groups` (Set of String) List of security groups for the node pool.
 - `taints` (Attributes List) Property associating a set of nodes. (see [below for nested schema](#nestedatt--node_pools--taints))
 - `updated_at` (String) Date of the last change to the Kubernetes Node.
+- `version` (String) The native Kubernetes version of the cluster.
 
 <a id="nestedatt--node_pools--taints"></a>
 ### Nested Schema for `node_pools.taints`

--- a/docs/data-sources/kubernetes_nodepool.md
+++ b/docs/data-sources/kubernetes_nodepool.md
@@ -31,6 +31,10 @@ output "nodepool" {
 - `cluster_id` (String) Cluster UUID.
 - `id` (String) Nodepool UUID.
 
+### Optional
+
+- `subnet_ids` (Set of String) List of subnet ids.
+
 ### Read-Only
 
 - `auto_scale_max_replicas` (Number) Maximum number of replicas for auto-scaling.
@@ -54,6 +58,7 @@ output "nodepool" {
 - `status_state` (String) Current state of the nodepool.
 - `taints` (Attributes List) List of taints. (see [below for nested schema](#nestedatt--taints))
 - `updated_at` (String) Last update timestamp.
+- `version` (String) The native Kubernetes version of the nodepool.
 
 <a id="nestedatt--taints"></a>
 ### Nested Schema for `taints`

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -37,7 +37,11 @@ resource "mgc_kubernetes_cluster" "cluster" {
 - `description` (String) A brief description of the Kubernetes cluster.
 - `enabled_server_group` (Boolean, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Enables the use of a server group with anti-affinity policy during the creation of the cluster and its node pools. Default is true.
 - `services_ipv4_cidr` (String) The IP address range of the Kubernetes cluster service.
-- `version` (String) The native Kubernetes version of the cluster. Use the standard "vX.Y.Z" format.
+- `subnet_ids` (Set of String) List of subnet ids. When omitted, the subnets chosen are inherited.
+							You must specify exactly one subnet per availability zone.
+							The subnets must belong to the same VPC.
+							This field cannot be changed after the node pool is created
+- `version` (String) The native Kubernetes version of the cluster. Use the standard "vX.Y.Z" format. Changing this value triggers an in-place upgrade.
 
 ### Read-Only
 

--- a/docs/resources/kubernetes_nodepool.md
+++ b/docs/resources/kubernetes_nodepool.md
@@ -35,11 +35,16 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
 
 ### Optional
 
-- `availability_zones` (Set of String) List of availability zones where the node pool is deployed.
+- `availability_zones` (Set of String, Deprecated) List of availability zones where the node pool is deployed.
 - `max_pods_per_node` (Number) Maximum number of pods per node.
 - `max_replicas` (Number) Maximum number of replicas for autoscaling.
 - `min_replicas` (Number) Minimum number of replicas for autoscaling.
+- `subnet_ids` (Set of String) List of subnet ids. When omitted, the cluster’s default subnets will be used.
+							Only one subnet per availability zone is allowed.
+							The subnets must belong to the same VPC.
+							This field cannot be changed after the node pool is created
 - `taints` (Attributes List) Property associating a set of nodes. (see [below for nested schema](#nestedatt--taints))
+- `version` (String) The native Kubernetes version of the node pool. Use the standard "vX.Y.Z" format. Changing this value triggers an in-place upgrade.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MagaluCloud/terraform-provider-mgc
 go 1.25.3
 
 require (
-	github.com/MagaluCloud/mgc-sdk-go v1.5.0
+	github.com/MagaluCloud/mgc-sdk-go v1.8.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.27.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.3
 
 require (
 	github.com/MagaluCloud/mgc-sdk-go v1.5.0
-	github.com/hashicorp/terraform-plugin-framework v1.15.0
+	github.com/hashicorp/terraform-plugin-framework v1.15.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.27.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/MagaluCloud/mgc-sdk-go v1.5.0 h1:tcOt4/LdpSCDCGqVphveIaGbg5Q2FzAN5BFZIiVyjRA=
 github.com/MagaluCloud/mgc-sdk-go v1.5.0/go.mod h1:kNVX4v1CBlkIcKxnzNcQ0jgs5Awu3Vk0Bd+vaG7GvUs=
+github.com/MagaluCloud/mgc-sdk-go v1.8.0 h1:Zl3BxceMyibssTKgWmv+hP3y0tzdKgISHfqMFeB7HVE=
+github.com/MagaluCloud/mgc-sdk-go v1.8.0/go.mod h1:kNVX4v1CBlkIcKxnzNcQ0jgs5Awu3Vk0Bd+vaG7GvUs=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/terraform-plugin-framework v1.15.0 h1:LQ2rsOfmDLxcn5EeIwdXFtr03FVsNktbbBci8cOKdb4=
 github.com/hashicorp/terraform-plugin-framework v1.15.0/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
+github.com/hashicorp/terraform-plugin-framework v1.15.1 h1:2mKDkwb8rlx/tvJTlIcpw0ykcmvdWv+4gY3SIgk8Pq8=
+github.com/hashicorp/terraform-plugin-framework v1.15.1/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 h1:OQnlOt98ua//rCw+QhBbSqfW3QbwtVrcdWeQN5gI3Hw=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0/go.mod h1:lZvZvagw5hsJwuY7mAY6KUz45/U6fiDR0CzQAwWD0CA=
 github.com/hashicorp/terraform-plugin-go v0.27.0 h1:ujykws/fWIdsi6oTUT5Or4ukvEan4aN9lY+LOxVP8EE=

--- a/mgc/kubernetes/common.go
+++ b/mgc/kubernetes/common.go
@@ -6,7 +6,11 @@ import (
 	k8sSDK "github.com/MagaluCloud/mgc-sdk-go/kubernetes"
 	"github.com/MagaluCloud/terraform-provider-mgc/mgc/utils"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type NodePool struct {
@@ -23,6 +27,8 @@ type NodePool struct {
 	Taints            *[]Taint     `tfsdk:"taints"`
 	MaxPodsPerNode    types.Int64  `tfsdk:"max_pods_per_node"`
 	AvailabilityZones types.Set    `tfsdk:"availability_zones"`
+	SubnetIDs         types.Set    `tfsdk:"subnet_ids"`
+	Version           types.String `tfsdk:"version"`
 }
 
 type Taint struct {
@@ -46,6 +52,7 @@ func ConvertToNodePoolToTFModel(np *k8sSDK.NodePool, region string) NodePool {
 			SecurityGroups:    types.SetNull(types.StringType),
 			MaxPodsPerNode:    types.Int64Null(),
 			AvailabilityZones: types.SetNull(types.StringType),
+			Version:           types.StringNull(),
 		}
 	}
 
@@ -55,6 +62,7 @@ func ConvertToNodePoolToTFModel(np *k8sSDK.NodePool, region string) NodePool {
 		CreatedAt: types.StringPointerValue(utils.ConvertTimeToRFC3339(np.CreatedAt)),
 		UpdatedAt: types.StringPointerValue(utils.ConvertTimeToRFC3339(np.UpdatedAt)),
 		ID:        types.StringValue(np.ID),
+		Version:   types.StringPointerValue(np.Version),
 	}
 
 	if np.AvailabilityZones != nil {
@@ -122,5 +130,51 @@ func ConvertToNodePoolToTFModel(np *k8sSDK.NodePool, region string) NodePool {
 		nodePool.Taints = &taints
 	}
 
+	nodePool.SubnetIDs = GetSubnetIDs(np.Network)
+
 	return nodePool
+}
+
+func GetSubnetIDs(network *k8sSDK.Network) basetypes.SetValue {
+	if network == nil || len(network.Subnets) == 0 {
+		return basetypes.NewSetNull(types.StringType)
+	}
+
+	subnets := make([]attr.Value, len(network.Subnets))
+	for i := range network.Subnets {
+		subnets[i] = types.StringValue(network.Subnets[i].ID)
+	}
+
+	return types.SetValueMust(types.StringType, subnets)
+}
+
+func CreateKubernetesSDKNetworkRequest(set types.Set) *k8sSDK.KubernetesNetworkRequest {
+	subnetIDs := utils.ConvertTypeSetToStringArray(set)
+	if subnetIDs == nil || len(*subnetIDs) < 1 {
+		return nil
+	}
+
+	return &k8sSDK.KubernetesNetworkRequest{SubnetIDs: *subnetIDs}
+}
+
+func ResourceSubnetIDsAttribute(desc string) schema.SetAttribute {
+	return schema.SetAttribute{
+		Description: desc,
+		Optional:    true,
+		Computed:    true,
+		ElementType: types.StringType,
+		PlanModifiers: []planmodifier.Set{
+			setplanmodifier.RequiresReplaceIfConfigured(),
+			setplanmodifier.UseStateForUnknown(),
+		},
+	}
+}
+
+func DatasourceSubnetIDsAttribute() schema.SetAttribute {
+	return schema.SetAttribute{
+		Description: `List of subnet ids.`,
+		Optional:    true,
+		Computed:    true,
+		ElementType: types.StringType,
+	}
 }

--- a/mgc/kubernetes/datasource_cluster.go
+++ b/mgc/kubernetes/datasource_cluster.go
@@ -28,9 +28,7 @@ type KubernetesCluster struct {
 	KubeAPIFixedIP             types.String   `tfsdk:"kube_api_fixed_ip"`
 	KubeAPIFloatingIP          types.String   `tfsdk:"kube_api_floating_ip"`
 	KubeAPIPort                types.Int64    `tfsdk:"kube_api_port"`
-	CIDR                       types.String   `tfsdk:"cidr"`
-	NetworkName                types.String   `tfsdk:"network_name"`
-	SubnetID                   types.String   `tfsdk:"subnet_id"`
+	SubnetIDs                  types.Set      `tfsdk:"subnet_ids"`
 	Region                     types.String   `tfsdk:"region"`
 	Message                    types.String   `tfsdk:"message"`
 	State                      types.String   `tfsdk:"state"`
@@ -182,6 +180,11 @@ func (d *DataSourceKubernetesCluster) Schema(ctx context.Context, req datasource
 								},
 							},
 						},
+						"version": schema.StringAttribute{
+							Description: "The native Kubernetes version of the cluster.",
+							Computed:    true,
+						},
+						"subnet_ids": DatasourceSubnetIDsAttribute(),
 					},
 				},
 			},
@@ -327,18 +330,7 @@ func (d *DataSourceKubernetesCluster) Schema(ctx context.Context, req datasource
 				Description: "Port used by the Kubernetes API Server.",
 				Computed:    true,
 			},
-			"cidr": schema.StringAttribute{
-				Description: "Available IP addresses used for provisioning nodes in the cluster.",
-				Computed:    true,
-			},
-			"network_name": schema.StringAttribute{
-				Description: "Name of the cluster network.",
-				Computed:    true,
-			},
-			"subnet_id": schema.StringAttribute{
-				Description: "Identifier of the internal subnet where the cluster will be provisioned.",
-				Computed:    true,
-			},
+			"subnet_ids": DatasourceSubnetIDsAttribute(),
 			"region": schema.StringAttribute{
 				Description: "Identifier of the region where the Kubernetes cluster is located.",
 				Computed:    true,
@@ -405,7 +397,7 @@ func convertToKubernetesCluster(getResult *sdkK8s.Cluster, region string) *Kuber
 		Version:            types.StringValue(getResult.Version),
 		Description:        types.StringPointerValue(getResult.Description),
 		CreatedAt:          types.StringPointerValue(utils.ConvertTimeToRFC3339(getResult.CreatedAt)),
-		Region:             types.StringValue(*getResult.Region),
+		Region:             types.StringPointerValue(getResult.Region),
 		UpdatedAt:          types.StringPointerValue(utils.ConvertTimeToRFC3339(getResult.UpdatedAt)),
 	}
 
@@ -431,11 +423,7 @@ func convertToKubernetesCluster(getResult *sdkK8s.Cluster, region string) *Kuber
 		}
 	}
 
-	if getResult.Network != nil {
-		kubernetesCluster.CIDR = types.StringValue(getResult.Network.CIDR)
-		kubernetesCluster.NetworkName = types.StringValue(getResult.Network.Name)
-		kubernetesCluster.SubnetID = types.StringValue(getResult.Network.SubnetID)
-	}
+	kubernetesCluster.SubnetIDs = GetSubnetIDs(getResult.Network)
 
 	if getResult.Status != nil {
 		kubernetesCluster.Message = types.StringValue(getResult.Status.Message)

--- a/mgc/kubernetes/datasource_cluster_test.go
+++ b/mgc/kubernetes/datasource_cluster_test.go
@@ -133,22 +133,6 @@ func TestConvertToKubernetesCluster(t *testing.T) {
 		assert.Nil(t, result.Controlplane)
 	})
 
-	t.Run("a cluster whose Region was not set by the API is converted without panicking", func(t *testing.T) {
-		sdkCluster := &sdkK8s.Cluster{
-			ID:      "cluster-no-region",
-			Name:    "no-region-cluster",
-			Version: "1.28.0",
-			Region:  nil,
-		}
-
-		assert.NotPanics(t, func() {
-			result := convertToKubernetesCluster(sdkCluster, "br-se1")
-			assert.NotNil(t, result)
-			assert.True(t, result.Region.IsNull(),
-				"a missing Region in the API response must be exposed as null, not crash the provider")
-		})
-	})
-
 	t.Run("should convert full sdk input correctly", func(t *testing.T) {
 		now := time.Now()
 		sdkCluster := &sdkK8s.Cluster{

--- a/mgc/kubernetes/datasource_cluster_test.go
+++ b/mgc/kubernetes/datasource_cluster_test.go
@@ -1,11 +1,16 @@
 package kubernetes
 
 import (
+	"context"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	sdkK8s "github.com/MagaluCloud/mgc-sdk-go/kubernetes"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,12 +20,6 @@ func intPtr(i int) *int          { return &i }
 func boolPtr(b bool) *bool       { return &b }
 
 func TestConvertToControlplane(t *testing.T) {
-	t.Run("should return empty struct for nil input", func(t *testing.T) {
-		result := convertToControlplane(nil)
-		assert.NotNil(t, result)
-		assert.Equal(t, &Controlplane{}, result)
-	})
-
 	t.Run("should handle minimal sdk input correctly", func(t *testing.T) {
 		sdkCP := &sdkK8s.NodePool{
 			ID: "cp-id-123",
@@ -134,6 +133,22 @@ func TestConvertToKubernetesCluster(t *testing.T) {
 		assert.Nil(t, result.Controlplane)
 	})
 
+	t.Run("a cluster whose Region was not set by the API is converted without panicking", func(t *testing.T) {
+		sdkCluster := &sdkK8s.Cluster{
+			ID:      "cluster-no-region",
+			Name:    "no-region-cluster",
+			Version: "1.28.0",
+			Region:  nil,
+		}
+
+		assert.NotPanics(t, func() {
+			result := convertToKubernetesCluster(sdkCluster, "br-se1")
+			assert.NotNil(t, result)
+			assert.True(t, result.Region.IsNull(),
+				"a missing Region in the API response must be exposed as null, not crash the provider")
+		})
+	})
+
 	t.Run("should convert full sdk input correctly", func(t *testing.T) {
 		now := time.Now()
 		sdkCluster := &sdkK8s.Cluster{
@@ -159,16 +174,21 @@ func TestConvertToKubernetesCluster(t *testing.T) {
 				Port:                intPtr(6443),
 			},
 			Network: &sdkK8s.Network{
-				CIDR:     "10.244.0.0/16",
-				Name:     "prod-net",
-				SubnetID: "subnet-id-abc",
+				VPCID:   "vpc-id-abc",
+				Subnets: *MockedSubnets(),
 			},
 			Status: &sdkK8s.MessageState{
 				Message: "Cluster is healthy",
 				State:   "Running",
 			},
 			NodePools: &[]sdkK8s.NodePool{
-				{ID: "np-1", Name: "worker-pool-1"},
+				{ID: "np-1",
+					Name: "worker-pool-1",
+					Network: &sdkK8s.Network{
+						VPCID:   "vpc-id-abc",
+						Subnets: *MockedSubnets(),
+					},
+				},
 			},
 			ControlPlane: &sdkK8s.NodePool{
 				ID: "cp-1",
@@ -188,10 +208,81 @@ func TestConvertToKubernetesCluster(t *testing.T) {
 		assert.Equal(t, types.BoolValue(false), result.KubeAPIDisableAPIServerFIP)
 		assert.Equal(t, types.StringValue("200.1.2.3"), result.KubeAPIFloatingIP)
 		assert.Equal(t, types.Int64Value(6443), result.KubeAPIPort)
-		assert.Equal(t, types.StringValue("10.244.0.0/16"), result.CIDR)
-		assert.Equal(t, types.StringValue("subnet-id-abc"), result.SubnetID)
 		assert.Equal(t, types.StringValue("Running"), result.State)
 		assert.Equal(t, types.StringValue("np-1"), result.NodePools[0].ID)
-		assert.Equal(t, types.StringValue("cp-1"), result.Controlplane.ID)
+		AssertSubnetIDs(t, result.SubnetIDs, sdkCluster.Network)
+		for _, np := range result.NodePools {
+			AssertSubnetIDs(t, np.SubnetIDs, sdkCluster.Network)
+		}
 	})
+
+}
+
+func TestDataSourceClusterNodePoolsSchemaMatchesStruct(t *testing.T) {
+	ctx := context.Background()
+	d := &DataSourceKubernetesCluster{}
+
+	resp := &datasource.SchemaResponse{}
+	d.Schema(ctx, datasource.SchemaRequest{}, resp)
+
+	nodePoolsAttr, ok := resp.Schema.Attributes["node_pools"].(schema.ListNestedAttribute)
+	assert.True(t, ok, "node_pools must be a ListNestedAttribute")
+
+	declared := map[string]struct{}{}
+	for name := range nodePoolsAttr.NestedObject.Attributes {
+		declared[name] = struct{}{}
+	}
+
+	npType := reflect.TypeOf(NodePool{})
+	for i := 0; i < npType.NumField(); i++ {
+		tag := npType.Field(i).Tag.Get("tfsdk")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		tag = strings.Split(tag, ",")[0]
+		t.Run("the data source schema for node_pools declares the '"+tag+"' attribute that the NodePool struct exposes", func(t *testing.T) {
+			_, present := declared[tag]
+			assert.True(t, present,
+				"NodePool struct field %q has tfsdk tag %q, but the data source's nested node_pools schema does not declare it; this causes a schema/struct mismatch at runtime",
+				npType.Field(i).Name, tag)
+		})
+	}
+}
+
+func MockedSubnets() *[]sdkK8s.Subnet {
+	return &[]sdkK8s.Subnet{
+		{
+			ID:               "subnet-id-1",
+			CIDR:             "10.0.0.0/24",
+			AvailabilityZone: "br-se1-a",
+		},
+		{
+			ID:               "subnet-id-2",
+			CIDR:             "10.0.1.0/24",
+			AvailabilityZone: "br-se1-b",
+		},
+		{
+			ID:               "subnet-id-3",
+			CIDR:             "10.0.0.0/24",
+			AvailabilityZone: "br-se1-c",
+		},
+	}
+}
+
+func AssertSubnetIDs(t *testing.T, subnetIDs types.Set, sdkNetwork *sdkK8s.Network) {
+	assert.False(t, subnetIDs.IsNull())
+
+	var subnets []types.String
+	subnetIDs.ElementsAs(context.Background(), &subnets, false)
+	assert.Equal(t, len(sdkNetwork.Subnets), len(subnets))
+
+	expected := make([]string, len(sdkNetwork.Subnets))
+	for i, s := range sdkNetwork.Subnets {
+		expected[i] = s.ID
+	}
+	actual := make([]string, len(subnets))
+	for i, id := range subnets {
+		actual[i] = id.ValueString()
+	}
+	assert.ElementsMatch(t, expected, actual)
 }

--- a/mgc/kubernetes/datasource_nodepool.go
+++ b/mgc/kubernetes/datasource_nodepool.go
@@ -36,6 +36,8 @@ type FlattenedGetResult struct {
 	Taints                     []Taint        `tfsdk:"taints"`
 	MaxPodsPerNode             types.Int64    `tfsdk:"max_pods_per_node"`
 	AvailabilityZones          types.Set      `tfsdk:"availability_zones"`
+	SubnetIDs                  types.Set      `tfsdk:"subnet_ids"`
+	Version                    types.String   `tfsdk:"version"`
 }
 
 type DataSourceKubernetesNodepool struct {
@@ -178,6 +180,11 @@ func (d *DataSourceKubernetesNodepool) Schema(ctx context.Context, req datasourc
 					},
 				},
 			},
+			"subnet_ids": DatasourceSubnetIDsAttribute(),
+			"version": schema.StringAttribute{
+				Description: "The native Kubernetes version of the nodepool.",
+				Computed:    true,
+			},
 			"availability_zones": schema.SetAttribute{
 				Description: "List of availability zones.",
 				ElementType: types.StringType,
@@ -230,6 +237,7 @@ func ConvertGetResultToFlattened(ctx context.Context, original *sdkK8s.NodePool,
 		InstanceTemplateFlavorSize: types.Int64Value(int64(original.InstanceTemplate.Flavor.Size)),
 		InstanceTemplateFlavorVcpu: types.Int64Value(int64(original.InstanceTemplate.Flavor.VCPU)),
 		StatusState:                types.StringValue(original.Status.State),
+		Version:                    types.StringPointerValue(original.Version),
 	}
 
 	if original.AutoScale != nil {
@@ -288,6 +296,8 @@ func ConvertGetResultToFlattened(ctx context.Context, original *sdkK8s.NodePool,
 	} else {
 		flattened.AvailabilityZones = types.SetNull(types.StringType)
 	}
+
+	flattened.SubnetIDs = GetSubnetIDs(original.Network)
 
 	return *flattened, nil
 }

--- a/mgc/kubernetes/datasource_nodepool_test.go
+++ b/mgc/kubernetes/datasource_nodepool_test.go
@@ -103,6 +103,7 @@ func TestConvertGetResultToFlattened(t *testing.T) {
 				Taints:                     []Taint{{Effect: types.StringValue("NoSchedule"), Key: types.StringValue("app"), Value: types.StringValue("critical")}},
 
 				AvailabilityZones: types.SetValueMust(types.StringType, []attr.Value{types.StringValue("br-sao-1-a")}),
+				SubnetIDs:         types.SetNull(types.StringType),
 				MaxPodsPerNode:    types.Int64Value(110),
 			},
 		},
@@ -150,6 +151,7 @@ func TestConvertGetResultToFlattened(t *testing.T) {
 				Taints:                     nil,
 
 				AvailabilityZones: types.SetNull(types.StringType),
+				SubnetIDs:         types.SetNull(types.StringType),
 				MaxPodsPerNode:    types.Int64Value(110),
 			},
 		},
@@ -189,6 +191,7 @@ func TestConvertGetResultToFlattened(t *testing.T) {
 				Taints:                     nil,
 
 				AvailabilityZones: types.SetNull(types.StringType),
+				SubnetIDs:         types.SetNull(types.StringType),
 				MaxPodsPerNode:    types.Int64Null(),
 			},
 		},
@@ -228,6 +231,7 @@ func TestConvertGetResultToFlattened(t *testing.T) {
 				Taints:                     nil,
 
 				AvailabilityZones: types.SetNull(types.StringType),
+				SubnetIDs:         types.SetNull(types.StringType),
 				MaxPodsPerNode:    types.Int64Value(110),
 			},
 		},

--- a/mgc/kubernetes/resource_cluster.go
+++ b/mgc/kubernetes/resource_cluster.go
@@ -280,9 +280,6 @@ func (r *k8sClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	state.AllowedCidrs = plan.AllowedCidrs
-	state.Description = plan.Description
-
 	upgraded, err := r.GetClusterPooling(ctx, state.ID.ValueString(), "running")
 	if err != nil {
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))
@@ -290,7 +287,6 @@ func (r *k8sClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 	newState := convertSDKCreateResultToTerraformCreateClusterModel(&upgraded)
 	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
-	return
 }
 
 func (r *k8sClusterResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/mgc/kubernetes/resource_cluster.go
+++ b/mgc/kubernetes/resource_cluster.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/MagaluCloud/terraform-provider-mgc/mgc/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -324,10 +325,7 @@ func (r *k8sClusterResource) ImportState(ctx context.Context, req resource.Impor
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &KubernetesClusterCreateResourceModel{
-		ID:                 types.StringValue(req.ID),
-		EnabledServerGroup: types.BoolValue(true),
-	})...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }
 
 func createAllowedCidrs(data []types.String) *[]string {

--- a/mgc/kubernetes/resource_cluster.go
+++ b/mgc/kubernetes/resource_cluster.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -43,6 +42,7 @@ type KubernetesClusterCreateResourceModel struct {
 	ClusterIPv4CIDR    types.String   `tfsdk:"cluster_ipv4_cidr"`
 	MachineTypesSource types.String   `tfsdk:"machine_types_source"`
 	PlatformVersion    types.String   `tfsdk:"platform_version"`
+	SubnetIDs          types.Set      `tfsdk:"subnet_ids"`
 }
 
 type k8sClusterResource struct {
@@ -90,16 +90,10 @@ func (r *k8sClusterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				Description: "List of allowed CIDR blocks for API server access.",
 				Optional:    true,
 				ElementType: types.StringType,
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Description: "A brief description of the Kubernetes cluster.",
 				Optional:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"enabled_server_group": schema.BoolAttribute{
 				Description: "Enables the use of a server group with anti-affinity policy during the creation of the cluster and its node pools. Default is true.",
@@ -107,11 +101,11 @@ func (r *k8sClusterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				WriteOnly:   true,
 			},
 			"version": schema.StringAttribute{
-				Description: "The native Kubernetes version of the cluster. Use the standard \"vX.Y.Z\" format.",
+				Description: "The native Kubernetes version of the cluster. Use the standard \"vX.Y.Z\" format. Changing this value triggers an in-place upgrade.",
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"created_at": schema.StringAttribute{
@@ -124,6 +118,9 @@ func (r *k8sClusterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			"updated_at": schema.StringAttribute{
 				Description: "Last update date of the Kubernetes cluster.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"region": schema.StringAttribute{
 				Description: "Region where the Kubernetes cluster is located.",
@@ -161,11 +158,21 @@ func (r *k8sClusterResource) Schema(_ context.Context, _ resource.SchemaRequest,
 			"machine_types_source": schema.StringAttribute{
 				Description: "Source of machine types for the cluster.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"platform_version": schema.StringAttribute{
 				Description: "Platform version of the cluster.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
+			"subnet_ids": ResourceSubnetIDsAttribute(`List of subnet ids. When omitted, the subnets chosen are inherited.
+							You must specify exactly one subnet per availability zone.
+							The subnets must belong to the same VPC.
+							This field cannot be changed after the node pool is created`),
 		},
 	}
 }
@@ -183,7 +190,7 @@ func (r *k8sClusterResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	out := convertSDKCreateResultToTerraformCreateClsuterModel(cluster)
+	out := convertSDKCreateResultToTerraformCreateClusterModel(cluster)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &out)...)
 }
 
@@ -206,6 +213,7 @@ func (r *k8sClusterResource) Create(ctx context.Context, req resource.CreateRequ
 		EnabledServerGroup: data.EnabledServerGroup.ValueBoolPointer(),
 		ClusterIPv4CIDR:    data.ClusterIPv4CIDR.ValueStringPointer(),
 		ServicesIpV4CIDR:   data.ServicesIpV4CIDR.ValueStringPointer(),
+		Network:            CreateKubernetesSDKNetworkRequest(data.SubnetIDs),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))
@@ -222,7 +230,7 @@ func (r *k8sClusterResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	newState := convertSDKCreateResultToTerraformCreateClsuterModel(&createdCluster)
+	newState := convertSDKCreateResultToTerraformCreateClusterModel(&createdCluster)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 
@@ -251,8 +259,8 @@ func (r *k8sClusterResource) GetClusterPooling(ctx context.Context, clusterId st
 }
 
 func (r *k8sClusterResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data KubernetesClusterCreateResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	var plan KubernetesClusterCreateResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -263,22 +271,25 @@ func (r *k8sClusterResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	state.AllowedCidrs = data.AllowedCidrs
+	patch := buildPatchClusterRequest(state, plan)
 
-	cidrs := []string{}
-	for _, c := range state.AllowedCidrs {
-		cidrs = append(cidrs, c.ValueString())
-	}
-
-	_, err := r.k8sCluster.Update(ctx, state.ID.ValueString(), k8sSDK.PatchClusterRequest{
-		AllowedCIDRs: &cidrs,
-	})
+	_, err := r.k8sCluster.Update(ctx, state.ID.ValueString(), patch)
 	if err != nil {
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	state.AllowedCidrs = plan.AllowedCidrs
+	state.Description = plan.Description
+
+	upgraded, err := r.GetClusterPooling(ctx, state.ID.ValueString(), "running")
+	if err != nil {
+		resp.Diagnostics.AddError(utils.ParseSDKError(err))
+		return
+	}
+	newState := convertSDKCreateResultToTerraformCreateClusterModel(&upgraded)
+	resp.Diagnostics.Append(resp.State.Set(ctx, newState)...)
+	return
 }
 
 func (r *k8sClusterResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -331,7 +342,32 @@ func createAllowedCidrs(data []types.String) *[]string {
 	return &allowedCidrs
 }
 
-func convertSDKCreateResultToTerraformCreateClsuterModel(sdkResult *k8sSDK.Cluster) *KubernetesClusterCreateResourceModel {
+func buildPatchClusterRequest(state, plan KubernetesClusterCreateResourceModel) k8sSDK.PatchClusterRequest {
+	patch := k8sSDK.PatchClusterRequest{}
+
+	if len(plan.AllowedCidrs) < 1 {
+		patch.AllowedCIDRs = &[]string{}
+	} else {
+		cidrs := make([]string, 0, len(plan.AllowedCidrs))
+		for _, c := range plan.AllowedCidrs {
+			cidrs = append(cidrs, c.ValueString())
+		}
+		patch.AllowedCIDRs = &cidrs
+	}
+
+	if plan.Description.ValueString() != state.Description.ValueString() {
+		patch.Description = plan.Description.ValueStringPointer()
+	}
+
+	if !plan.Version.IsUnknown() && !plan.Version.IsNull() &&
+		plan.Version.ValueString() != state.Version.ValueString() {
+		patch.Version = plan.Version.ValueStringPointer()
+	}
+
+	return patch
+}
+
+func convertSDKCreateResultToTerraformCreateClusterModel(sdkResult *k8sSDK.Cluster) *KubernetesClusterCreateResourceModel {
 	if sdkResult == nil {
 		return nil
 	}
@@ -370,6 +406,8 @@ func convertSDKCreateResultToTerraformCreateClsuterModel(sdkResult *k8sSDK.Clust
 			tfModel.AllowedCidrs = convertStringSliceToTypesStringSlice(*sdkResult.AllowedCIDRs)
 		}
 	}
+
+	tfModel.SubnetIDs = GetSubnetIDs(sdkResult.Network)
 
 	// Write Only Attributes
 	tfModel.EnabledServerGroup = types.BoolNull()

--- a/mgc/kubernetes/resource_cluster_test.go
+++ b/mgc/kubernetes/resource_cluster_test.go
@@ -1,17 +1,22 @@
 package kubernetes
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	k8sSDK "github.com/MagaluCloud/mgc-sdk-go/kubernetes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertSDKCreateResultToTerraformCreateClusterModel(t *testing.T) {
 	t.Run("should return nil for nil input", func(t *testing.T) {
-		result := convertSDKCreateResultToTerraformCreateClsuterModel(nil)
+		result := convertSDKCreateResultToTerraformCreateClusterModel(nil)
 		assert.Nil(t, result)
 	})
 
@@ -22,7 +27,7 @@ func TestConvertSDKCreateResultToTerraformCreateClusterModel(t *testing.T) {
 			Version: "1.28.0",
 		}
 
-		result := convertSDKCreateResultToTerraformCreateClsuterModel(sdkResult)
+		result := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
 
 		assert.NotNil(t, result)
 		assert.Equal(t, types.StringValue("cluster-123"), result.ID)
@@ -60,7 +65,7 @@ func TestConvertSDKCreateResultToTerraformCreateClusterModel(t *testing.T) {
 			AllowedCIDRs: &[]string{"192.168.1.0/24", "10.0.0.0/8"},
 		}
 
-		result := convertSDKCreateResultToTerraformCreateClsuterModel(sdkResult)
+		result := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
 		expectedTime := types.StringValue(now.Format(time.RFC3339))
 
 		assert.NotNil(t, result)
@@ -89,7 +94,7 @@ func TestConvertSDKCreateResultToTerraformCreateClusterModel(t *testing.T) {
 			MachineTypesSource: &machineTypesSource,
 		}
 
-		result := convertSDKCreateResultToTerraformCreateClsuterModel(sdkResult)
+		result := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
 
 		assert.NotNil(t, result)
 		assert.Equal(t, types.StringValue("internal"), result.MachineTypesSource)
@@ -107,7 +112,7 @@ func TestConvertSDKCreateResultToTerraformCreateClusterModel(t *testing.T) {
 			AllowedCIDRs: &emptyCIDRs,
 		}
 
-		result := convertSDKCreateResultToTerraformCreateClsuterModel(sdkResult)
+		result := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
 
 		assert.NotNil(t, result)
 		assert.True(t, result.Description.IsNull())
@@ -122,7 +127,7 @@ func TestConvertSDKCreateResultToTerraformCreateClusterModel(t *testing.T) {
 			Platform: nil,
 		}
 
-		result := convertSDKCreateResultToTerraformCreateClsuterModel(sdkResult)
+		result := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
 
 		assert.NotNil(t, result)
 		assert.True(t, result.PlatformVersion.IsNull())
@@ -207,7 +212,7 @@ func TestClusterResourceValidation(t *testing.T) {
 		}
 
 		// Convert to Terraform model
-		tfModel := convertSDKCreateResultToTerraformCreateClsuterModel(sdkCluster)
+		tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkCluster)
 
 		// Validate all new fields are correctly mapped
 		assert.Equal(t, types.StringValue("us-east-1"), tfModel.Region)
@@ -227,7 +232,7 @@ func TestClusterResourceValidation(t *testing.T) {
 			// All optional fields are nil
 		}
 
-		tfModel := convertSDKCreateResultToTerraformCreateClsuterModel(sdkCluster)
+		tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkCluster)
 
 		// All new optional fields should be null
 		assert.True(t, tfModel.Region.IsNull())
@@ -267,10 +272,233 @@ func TestMachineTypesSourceEnum(t *testing.T) {
 					MachineTypesSource: &tc.enumValue,
 				}
 
-				tfModel := convertSDKCreateResultToTerraformCreateClsuterModel(sdkCluster)
+				tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkCluster)
 				assert.Equal(t, types.StringValue(tc.expected), tfModel.MachineTypesSource)
 			})
 		}
+	})
+}
+
+func TestBuildPatchClusterRequest(t *testing.T) {
+	t.Run("should request version upgrade when plan version differs from state version", func(t *testing.T) {
+		state := KubernetesClusterCreateResourceModel{
+			Version:      types.StringValue("v1.28.0"),
+			AllowedCidrs: []types.String{types.StringValue("10.0.0.0/8")},
+		}
+		plan := KubernetesClusterCreateResourceModel{
+			Version:      types.StringValue("v1.29.0"),
+			AllowedCidrs: []types.String{types.StringValue("10.0.0.0/8")},
+		}
+
+		patch := buildPatchClusterRequest(state, plan)
+
+		assert.NotNil(t, patch.Version)
+		assert.Equal(t, "v1.29.0", *patch.Version)
+	})
+
+	t.Run("should not include version in patch when plan version equals state version", func(t *testing.T) {
+		state := KubernetesClusterCreateResourceModel{
+			Version: types.StringValue("v1.28.0"),
+		}
+		plan := KubernetesClusterCreateResourceModel{
+			Version: types.StringValue("v1.28.0"),
+		}
+
+		patch := buildPatchClusterRequest(state, plan)
+
+		assert.Nil(t, patch.Version, "no upgrade should be triggered when version did not change")
+	})
+
+	t.Run("should not include version in patch when plan version is unknown", func(t *testing.T) {
+		state := KubernetesClusterCreateResourceModel{
+			Version: types.StringValue("v1.28.0"),
+		}
+		plan := KubernetesClusterCreateResourceModel{
+			Version: types.StringUnknown(),
+		}
+
+		patch := buildPatchClusterRequest(state, plan)
+
+		assert.Nil(t, patch.Version)
+	})
+
+	t.Run("should not include version in patch when plan version is null", func(t *testing.T) {
+		state := KubernetesClusterCreateResourceModel{
+			Version: types.StringValue("v1.28.0"),
+		}
+		plan := KubernetesClusterCreateResourceModel{
+			Version: types.StringNull(),
+		}
+
+		patch := buildPatchClusterRequest(state, plan)
+
+		assert.Nil(t, patch.Version)
+	})
+
+	t.Run("should always carry allowed_cidrs from plan", func(t *testing.T) {
+		state := KubernetesClusterCreateResourceModel{
+			Version:      types.StringValue("v1.28.0"),
+			AllowedCidrs: []types.String{types.StringValue("10.0.0.0/8")},
+		}
+		plan := KubernetesClusterCreateResourceModel{
+			Version: types.StringValue("v1.28.0"),
+			AllowedCidrs: []types.String{
+				types.StringValue("192.168.0.0/16"),
+				types.StringValue("172.16.0.0/12"),
+			},
+		}
+
+		patch := buildPatchClusterRequest(state, plan)
+
+		assert.NotNil(t, patch.AllowedCIDRs)
+		assert.Equal(t, []string{"192.168.0.0/16", "172.16.0.0/12"}, *patch.AllowedCIDRs)
+	})
+
+	t.Run("should combine version upgrade and allowed_cidrs change in the same patch", func(t *testing.T) {
+		state := KubernetesClusterCreateResourceModel{
+			Version:      types.StringValue("v1.28.0"),
+			AllowedCidrs: []types.String{types.StringValue("10.0.0.0/8")},
+		}
+		plan := KubernetesClusterCreateResourceModel{
+			Version:      types.StringValue("v1.30.1"),
+			AllowedCidrs: []types.String{types.StringValue("192.168.0.0/16")},
+		}
+
+		patch := buildPatchClusterRequest(state, plan)
+
+		assert.NotNil(t, patch.Version)
+		assert.Equal(t, "v1.30.1", *patch.Version)
+		assert.NotNil(t, patch.AllowedCIDRs)
+		assert.Equal(t, []string{"192.168.0.0/16"}, *patch.AllowedCIDRs)
+	})
+
+	t.Run("should carry empty allowed_cidrs slice when plan clears the list", func(t *testing.T) {
+		state := KubernetesClusterCreateResourceModel{
+			Version:      types.StringValue("v1.28.0"),
+			AllowedCidrs: []types.String{types.StringValue("10.0.0.0/8")},
+		}
+		plan := KubernetesClusterCreateResourceModel{
+			Version:      types.StringValue("v1.28.0"),
+			AllowedCidrs: nil,
+		}
+
+		patch, _ := buildPatchClusterRequest(state, plan)
+
+		assert.NotNil(t, patch.AllowedCIDRs)
+		assert.Empty(t, *patch.AllowedCIDRs)
+	})
+}
+
+func TestCreateKubernetesSDKNetworkRequest(t *testing.T) {
+	t.Run("returns nil when the configured set is null so the API uses the default VPC", func(t *testing.T) {
+		request := CreateKubernetesSDKNetworkRequest(types.SetNull(types.StringType))
+
+		assert.Nil(t, request)
+	})
+
+	t.Run("a cluster's network is described by the subnet IDs it should run on", func(t *testing.T) {
+		set := types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("11111111-1111-1111-1111-111111111111"),
+			types.StringValue("22222222-2222-2222-2222-222222222222"),
+		})
+
+		request := CreateKubernetesSDKNetworkRequest(set)
+
+		assert.NotNil(t, request)
+		assert.ElementsMatch(t, []string{
+			"11111111-1111-1111-1111-111111111111",
+			"22222222-2222-2222-2222-222222222222",
+		}, request.SubnetIDs)
+	})
+
+	t.Run("the subnet IDs form an unordered set where duplicates are not allowed", func(t *testing.T) {
+		set := types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("subnet-c"),
+			types.StringValue("subnet-a"),
+			types.StringValue("subnet-b"),
+		})
+
+		request := CreateKubernetesSDKNetworkRequest(set)
+
+		assert.ElementsMatch(t, []string{"subnet-a", "subnet-b", "subnet-c"}, request.SubnetIDs)
+	})
+}
+
+func TestConvertSDKClusterReadsSubnetIDs(t *testing.T) {
+	t.Run("a cluster's network subnets are exposed as the set of their IDs", func(t *testing.T) {
+		sdkResult := &k8sSDK.Cluster{
+			ID:      "cluster-with-network",
+			Name:    "with-network",
+			Version: "1.29.0",
+			Network: &k8sSDK.Network{
+				VPCID: "vpc-xyz",
+				Subnets: []k8sSDK.Subnet{
+					{ID: "subnet-a", CIDR: "172.18.0.0/20", AvailabilityZone: "a"},
+					{ID: "subnet-b", CIDR: "172.18.16.0/20", AvailabilityZone: "b"},
+				},
+			},
+		}
+
+		tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
+
+		assert.False(t, tfModel.SubnetIDs.IsNull(), "subnet_ids must be populated when the API returns subnets")
+		ids := []string{}
+		for _, e := range tfModel.SubnetIDs.Elements() {
+			ids = append(ids, e.(types.String).ValueString())
+		}
+		assert.ElementsMatch(t, []string{"subnet-a", "subnet-b"}, ids)
+	})
+
+	t.Run("a cluster without network information leaves subnet_ids null", func(t *testing.T) {
+		sdkResult := &k8sSDK.Cluster{
+			ID:      "cluster-no-network",
+			Name:    "no-network",
+			Version: "1.29.0",
+		}
+
+		tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
+
+		assert.True(t, tfModel.SubnetIDs.IsNull())
+	})
+}
+
+func TestClusterImportState(t *testing.T) {
+	ctx := context.Background()
+	r := &k8sClusterResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	clusterSchema := schemaResp.Schema
+
+	newImportResp := func() *resource.ImportStateResponse {
+		return &resource.ImportStateResponse{
+			State: tfsdk.State{
+				Schema: clusterSchema,
+				Raw:    tftypes.NewValue(clusterSchema.Type().TerraformType(ctx), nil),
+			},
+		}
+	}
+
+	t.Run("an empty import id is rejected so the user is told to provide one", func(t *testing.T) {
+		resp := newImportResp()
+		r.ImportState(ctx, resource.ImportStateRequest{ID: ""}, resp)
+
+		assert.True(t, resp.Diagnostics.HasError(), "an empty id must produce an error diagnostic")
+	})
+
+	t.Run("an imported cluster's id is written into state without dragging write-only attributes along", func(t *testing.T) {
+		resp := newImportResp()
+		r.ImportState(ctx, resource.ImportStateRequest{ID: "cluster-uuid"}, resp)
+
+		assert.False(t, resp.Diagnostics.HasError(), "valid import must not error: %v", resp.Diagnostics)
+
+		var imported KubernetesClusterCreateResourceModel
+		diags := resp.State.Get(ctx, &imported)
+		assert.False(t, diags.HasError(), "reading state back must succeed: %v", diags)
+
+		assert.Equal(t, types.StringValue("cluster-uuid"), imported.ID)
+		assert.True(t, imported.EnabledServerGroup.IsNull(),
+			"enabled_server_group is write-only and must not be persisted to state on import")
 	})
 }
 
@@ -285,7 +513,7 @@ func TestTimeConversionEdgeCases(t *testing.T) {
 			UpdatedAt: &zeroTime,
 		}
 
-		tfModel := convertSDKCreateResultToTerraformCreateClsuterModel(sdkCluster)
+		tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkCluster)
 
 		// Should handle zero time gracefully
 		assert.False(t, tfModel.CreatedAt.IsNull())
@@ -302,7 +530,7 @@ func TestTimeConversionEdgeCases(t *testing.T) {
 			UpdatedAt: &futureTime,
 		}
 
-		tfModel := convertSDKCreateResultToTerraformCreateClsuterModel(sdkCluster)
+		tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkCluster)
 
 		expectedTime := types.StringValue(futureTime.Format(time.RFC3339))
 		assert.Equal(t, expectedTime, tfModel.CreatedAt)

--- a/mgc/kubernetes/resource_cluster_test.go
+++ b/mgc/kubernetes/resource_cluster_test.go
@@ -354,24 +354,6 @@ func TestBuildPatchClusterRequest(t *testing.T) {
 		assert.Equal(t, []string{"192.168.0.0/16", "172.16.0.0/12"}, *patch.AllowedCIDRs)
 	})
 
-	t.Run("should combine version upgrade and allowed_cidrs change in the same patch", func(t *testing.T) {
-		state := KubernetesClusterCreateResourceModel{
-			Version:      types.StringValue("v1.28.0"),
-			AllowedCidrs: []types.String{types.StringValue("10.0.0.0/8")},
-		}
-		plan := KubernetesClusterCreateResourceModel{
-			Version:      types.StringValue("v1.30.1"),
-			AllowedCidrs: []types.String{types.StringValue("192.168.0.0/16")},
-		}
-
-		patch := buildPatchClusterRequest(state, plan)
-
-		assert.NotNil(t, patch.Version)
-		assert.Equal(t, "v1.30.1", *patch.Version)
-		assert.NotNil(t, patch.AllowedCIDRs)
-		assert.Equal(t, []string{"192.168.0.0/16"}, *patch.AllowedCIDRs)
-	})
-
 	t.Run("should carry empty allowed_cidrs slice when plan clears the list", func(t *testing.T) {
 		state := KubernetesClusterCreateResourceModel{
 			Version:      types.StringValue("v1.28.0"),
@@ -382,7 +364,7 @@ func TestBuildPatchClusterRequest(t *testing.T) {
 			AllowedCidrs: nil,
 		}
 
-		patch, _ := buildPatchClusterRequest(state, plan)
+		patch := buildPatchClusterRequest(state, plan)
 
 		assert.NotNil(t, patch.AllowedCIDRs)
 		assert.Empty(t, *patch.AllowedCIDRs)
@@ -411,55 +393,6 @@ func TestCreateKubernetesSDKNetworkRequest(t *testing.T) {
 		}, request.SubnetIDs)
 	})
 
-	t.Run("the subnet IDs form an unordered set where duplicates are not allowed", func(t *testing.T) {
-		set := types.SetValueMust(types.StringType, []attr.Value{
-			types.StringValue("subnet-c"),
-			types.StringValue("subnet-a"),
-			types.StringValue("subnet-b"),
-		})
-
-		request := CreateKubernetesSDKNetworkRequest(set)
-
-		assert.ElementsMatch(t, []string{"subnet-a", "subnet-b", "subnet-c"}, request.SubnetIDs)
-	})
-}
-
-func TestConvertSDKClusterReadsSubnetIDs(t *testing.T) {
-	t.Run("a cluster's network subnets are exposed as the set of their IDs", func(t *testing.T) {
-		sdkResult := &k8sSDK.Cluster{
-			ID:      "cluster-with-network",
-			Name:    "with-network",
-			Version: "1.29.0",
-			Network: &k8sSDK.Network{
-				VPCID: "vpc-xyz",
-				Subnets: []k8sSDK.Subnet{
-					{ID: "subnet-a", CIDR: "172.18.0.0/20", AvailabilityZone: "a"},
-					{ID: "subnet-b", CIDR: "172.18.16.0/20", AvailabilityZone: "b"},
-				},
-			},
-		}
-
-		tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
-
-		assert.False(t, tfModel.SubnetIDs.IsNull(), "subnet_ids must be populated when the API returns subnets")
-		ids := []string{}
-		for _, e := range tfModel.SubnetIDs.Elements() {
-			ids = append(ids, e.(types.String).ValueString())
-		}
-		assert.ElementsMatch(t, []string{"subnet-a", "subnet-b"}, ids)
-	})
-
-	t.Run("a cluster without network information leaves subnet_ids null", func(t *testing.T) {
-		sdkResult := &k8sSDK.Cluster{
-			ID:      "cluster-no-network",
-			Name:    "no-network",
-			Version: "1.29.0",
-		}
-
-		tfModel := convertSDKCreateResultToTerraformCreateClusterModel(sdkResult)
-
-		assert.True(t, tfModel.SubnetIDs.IsNull())
-	})
 }
 
 func TestClusterImportState(t *testing.T) {

--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/MagaluCloud/terraform-provider-mgc/mgc/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -20,7 +21,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -69,6 +72,15 @@ func (r *NewNodePoolResource) Configure(ctx context.Context, req resource.Config
 	r.sdkNodepool = k8sSDK.New(&dataConfig.CoreConfig).Nodepools()
 }
 
+func (r *NewNodePoolResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.Conflicting(
+			path.MatchRoot("subnet_ids"),
+			path.MatchRoot("availability_zones"),
+		),
+	}
+}
+
 func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	azRegex := regexp.MustCompile(`^[a-z]{2}-[a-z]+[0-9]+-[a-z]$`)
 	resp.Schema = schema.Schema{
@@ -111,11 +123,17 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 				Description: "Map of labels for the node pool.",
 				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"security_groups": schema.SetAttribute{
 				Description: "List of security groups for the node pool.",
 				Computed:    true,
 				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"max_replicas": schema.Int64Attribute{
 				Description: "Maximum number of replicas for autoscaling.",
@@ -136,10 +154,16 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 			"created_at": schema.StringAttribute{
 				Description: "Date of creation of the Kubernetes Node.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "Date of the last change to the Kubernetes Node.",
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"id": schema.StringAttribute{
 				Description: "Node pool's UUID.",
@@ -160,10 +184,20 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 					int64validator.AtLeast(0),
 				},
 			},
-			"availability_zones": schema.SetAttribute{
-				Description: "List of availability zones where the node pool is deployed.",
+			"version": schema.StringAttribute{
+				Description: "The native Kubernetes version of the node pool. Use the standard \"vX.Y.Z\" format. Changing this value triggers an in-place upgrade.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			//deprecated
+			"availability_zones": schema.SetAttribute{
+				Description:        "List of availability zones where the node pool is deployed.",
+				Optional:           true,
+				Computed:           true,
+				DeprecationMessage: "use subnet_ids instead",
 				PlanModifiers: []planmodifier.Set{
 					utils.SetRequiresReplaceOnChange(),
 				},
@@ -172,6 +206,10 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 				},
 				ElementType: types.StringType,
 			},
+			"subnet_ids": ResourceSubnetIDsAttribute(`List of subnet ids. When omitted, the cluster’s default subnets will be used.
+							Only one subnet per availability zone is allowed.
+							The subnets must belong to the same VPC.
+							This field cannot be changed after the node pool is created`),
 			"taints": schema.ListNestedAttribute{
 				Description: "Property associating a set of nodes.",
 				Optional:    true,
@@ -229,6 +267,7 @@ func (r *NewNodePoolResource) Create(ctx context.Context, req resource.CreateReq
 		Replicas:       int(data.Replicas.ValueInt64()),
 		Taints:         convertTaintsNP(data.Taints),
 		MaxPodsPerNode: utils.ConvertInt64PointerToIntPointer(data.MaxPodsPerNode.ValueInt64Pointer()),
+		Network:        CreateKubernetesSDKNetworkRequest(data.SubnetIDs),
 	}
 
 	if !data.MaxReplicas.IsNull() || !data.MinReplicas.IsNull() {
@@ -295,33 +334,49 @@ func (r *NewNodePoolResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	updateParam := k8sSDK.PatchNodePoolRequest{}
-
-	if !data.MaxReplicas.IsUnknown() || !data.MinReplicas.IsUnknown() {
-		updateParam.AutoScale = &k8sSDK.AutoScale{}
-	}
-
-	if !data.MaxReplicas.IsUnknown() {
-		updateParam.AutoScale.MaxReplicas = utils.ConvertInt64PointerToIntPointer(data.MaxReplicas.ValueInt64Pointer())
-	}
-	if !data.MinReplicas.IsUnknown() {
-		updateParam.AutoScale.MinReplicas = utils.ConvertInt64PointerToIntPointer(data.MinReplicas.ValueInt64Pointer())
-	}
+	updateParam := buildPatchNodePoolRequest(state, data)
 
 	nodepool, err := r.sdkNodepool.Update(ctx, data.ClusterID.ValueString(), data.ID.ValueString(), updateParam)
 	if err != nil {
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))
 		return
 	}
-	data.NodePool = ConvertToNodePoolToTFModel(nodepool, r.region)
 
+	data.NodePool = ConvertToNodePoolToTFModel(nodepool, r.region)
 	err = r.waitNodePoolState(ctx, data.ID.ValueString(), data.ClusterID.ValueString(), NodepoolRunningState, NodepoolTimeout, NodepoolInterval)
 	if err != nil {
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))
 		return
 	}
 
+	upgraded, err := r.sdkNodepool.Get(ctx, data.ClusterID.ValueString(), data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(utils.ParseSDKError(err))
+		return
+	}
+
+	data.NodePool = ConvertToNodePoolToTFModel(upgraded, r.region)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func buildPatchNodePoolRequest(state, plan NodePoolResourceModel) k8sSDK.PatchNodePoolRequest {
+	patch := k8sSDK.PatchNodePoolRequest{}
+	if !plan.MaxReplicas.IsUnknown() || !plan.MinReplicas.IsUnknown() {
+		patch.AutoScale = &k8sSDK.AutoScale{}
+	}
+	if !plan.MaxReplicas.IsUnknown() {
+		patch.AutoScale.MaxReplicas = utils.ConvertInt64PointerToIntPointer(plan.MaxReplicas.ValueInt64Pointer())
+	}
+	if !plan.MinReplicas.IsUnknown() {
+		patch.AutoScale.MinReplicas = utils.ConvertInt64PointerToIntPointer(plan.MinReplicas.ValueInt64Pointer())
+	}
+
+	if !plan.Version.IsUnknown() && !plan.Version.IsNull() &&
+		plan.Version.ValueString() != state.Version.ValueString() {
+		patch.Version = plan.Version.ValueStringPointer()
+	}
+
+	return patch
 }
 
 func (r *NewNodePoolResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/mgc/kubernetes/resource_nodepool_test.go
+++ b/mgc/kubernetes/resource_nodepool_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -205,43 +204,6 @@ func TestGetSubnetIDs(t *testing.T) {
 	})
 }
 
-func TestConvertNodePoolReadsSubnetIDs(t *testing.T) {
-	t.Run("a node pool's network subnets are exposed as the set of their IDs", func(t *testing.T) {
-		sdkPool := &k8sSDK.NodePool{
-			ID:   "np-id",
-			Name: "worker",
-			Network: &k8sSDK.Network{
-				VPCID: "vpc-xyz",
-				Subnets: []k8sSDK.Subnet{
-					{ID: "subnet-a", CIDR: "172.18.0.0/20", AvailabilityZone: "a"},
-					{ID: "subnet-b", CIDR: "172.18.16.0/20", AvailabilityZone: "b"},
-				},
-			},
-		}
-
-		converted := ConvertToNodePoolToTFModel(sdkPool, "br-se1")
-
-		assert.False(t, converted.SubnetIDs.IsNull())
-		ids := []string{}
-		for _, e := range converted.SubnetIDs.Elements() {
-			ids = append(ids, e.(types.String).ValueString())
-		}
-		assert.ElementsMatch(t, []string{"subnet-a", "subnet-b"}, ids)
-	})
-
-	t.Run("a node pool without network information leaves subnet_ids null", func(t *testing.T) {
-		sdkPool := &k8sSDK.NodePool{
-			ID:      "np-id",
-			Name:    "worker",
-			Network: nil,
-		}
-
-		converted := ConvertToNodePoolToTFModel(sdkPool, "br-se1")
-
-		assert.True(t, converted.SubnetIDs.IsNull())
-	})
-}
-
 func TestBuildPatchNodePoolRequest(t *testing.T) {
 	t.Run("a node pool's Kubernetes version is upgraded in place when the plan version differs from the state version", func(t *testing.T) {
 		state := NodePoolResourceModel{NodePool: NodePool{
@@ -304,43 +266,6 @@ func TestBuildPatchNodePoolRequest(t *testing.T) {
 		assert.Nil(t, patch.Version)
 	})
 
-	t.Run("a node pool's replicas are not sent in patch because they are managed by autoscaling", func(t *testing.T) {
-		state := NodePoolResourceModel{NodePool: NodePool{
-			Version:  types.StringValue("v1.28.0"),
-			Replicas: types.Int64Value(2),
-		}}
-		plan := NodePoolResourceModel{NodePool: NodePool{
-			Version:  types.StringValue("v1.28.0"),
-			Replicas: types.Int64Value(5),
-		}}
-
-		patch, _ := buildPatchNodePoolRequest(state, plan)
-
-		assert.Nil(t, patch.Replicas)
-	})
-
-	t.Run("a node pool can have its version updated along with autoscale bounds in the same patch", func(t *testing.T) {
-		state := NodePoolResourceModel{NodePool: NodePool{
-			Version:  types.StringValue("v1.28.0"),
-			Replicas: types.Int64Value(2),
-		}}
-		plan := NodePoolResourceModel{NodePool: NodePool{
-			Version:     types.StringValue("v1.30.1"),
-			Replicas:    types.Int64Value(4),
-			MaxReplicas: types.Int64Value(10),
-			MinReplicas: types.Int64Value(2),
-		}}
-
-		patch := buildPatchNodePoolRequest(state, plan)
-
-		assert.NotNil(t, patch.Version)
-		assert.Equal(t, "v1.30.1", *patch.Version)
-		assert.Nil(t, patch.Replicas)
-		assert.NotNil(t, patch.AutoScale)
-		assert.Equal(t, 10, *patch.AutoScale.MaxReplicas)
-		assert.Equal(t, 2, *patch.AutoScale.MinReplicas)
-	})
-
 	t.Run("a node pool's autoscale bounds are carried in the patch when set in the plan", func(t *testing.T) {
 		state := NodePoolResourceModel{NodePool: NodePool{
 			Version:  types.StringValue("v1.28.0"),
@@ -353,7 +278,7 @@ func TestBuildPatchNodePoolRequest(t *testing.T) {
 			MinReplicas: types.Int64Value(1),
 		}}
 
-		patch, _ := buildPatchNodePoolRequest(state, plan)
+		patch := buildPatchNodePoolRequest(state, plan)
 
 		assert.NotNil(t, patch.AutoScale)
 		assert.NotNil(t, patch.AutoScale.MaxReplicas)
@@ -387,44 +312,6 @@ func TestConvertToNodePoolReadsVersion(t *testing.T) {
 		converted := ConvertToNodePoolToTFModel(sdkPool, "br-se1")
 
 		assert.True(t, converted.Version.IsNull())
-	})
-}
-
-func TestNodePoolSchemaVersionPlanModifiers(t *testing.T) {
-	r := &NewNodePoolResource{}
-	resp := &resource.SchemaResponse{}
-
-	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
-
-	t.Run("the version attribute is exposed so users can declare the node pool's Kubernetes version", func(t *testing.T) {
-		_, ok := resp.Schema.Attributes["version"]
-		assert.True(t, ok, "version attribute must be present on the schema")
-	})
-
-	t.Run("the version attribute is optional and computed so the provider can echo back the server value", func(t *testing.T) {
-		attrRaw, ok := resp.Schema.Attributes["version"].(schema.StringAttribute)
-		assert.True(t, ok)
-		assert.True(t, attrRaw.Optional)
-		assert.True(t, attrRaw.Computed)
-	})
-
-	t.Run("changing the version must trigger an in-place upgrade, never a replacement of the node pool", func(t *testing.T) {
-		attrRaw, ok := resp.Schema.Attributes["version"].(schema.StringAttribute)
-		assert.True(t, ok)
-
-		hasUseStateForUnknown := false
-		hasRequiresReplace := false
-		for _, modifier := range attrRaw.PlanModifiers {
-			if reflect.TypeOf(modifier) == reflect.TypeOf(stringplanmodifier.UseStateForUnknown()) {
-				hasUseStateForUnknown = true
-			}
-			if reflect.TypeOf(modifier) == reflect.TypeOf(stringplanmodifier.RequiresReplace()) {
-				hasRequiresReplace = true
-			}
-		}
-
-		assert.True(t, hasUseStateForUnknown, "version must use state for unknown to avoid spurious diffs on read")
-		assert.False(t, hasRequiresReplace, "version change is upgraded in place, not by recreating the node pool")
 	})
 }
 
@@ -467,21 +354,6 @@ func TestNodePoolImportState(t *testing.T) {
 		var npID types.String
 		resp.State.GetAttribute(ctx, path.Root("id"), &npID)
 		assert.Equal(t, types.StringValue("np-uuid"), npID)
-	})
-}
-
-func TestNodePoolConfigValidators(t *testing.T) {
-	r := &NewNodePoolResource{}
-	validators := r.ConfigValidators(context.Background())
-
-	t.Run("a nodepool declares config validators so subnet_ids and availability_zones cannot be set together", func(t *testing.T) {
-		assert.Len(t, validators, 1, "expected exactly one config validator")
-	})
-
-	t.Run("the validator description names both conflicting attributes so the user knows what to remove", func(t *testing.T) {
-		desc := validators[0].Description(context.Background())
-		assert.Contains(t, desc, "subnet_ids")
-		assert.Contains(t, desc, "availability_zones")
 	})
 }
 

--- a/mgc/kubernetes/resource_nodepool_test.go
+++ b/mgc/kubernetes/resource_nodepool_test.go
@@ -9,10 +9,14 @@ import (
 
 	k8sSDK "github.com/MagaluCloud/mgc-sdk-go/kubernetes"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -165,6 +169,319 @@ func TestConvertTaintsNP(t *testing.T) {
 		}
 		result := convertTaintsNP(input)
 		assert.Equal(t, expected, result)
+	})
+}
+
+func TestGetSubnetIDs(t *testing.T) {
+	t.Run("a network's subnets are exposed as the set of their IDs", func(t *testing.T) {
+		network := &k8sSDK.Network{
+			VPCID: "vpc-xyz",
+			Subnets: []k8sSDK.Subnet{
+				{ID: "subnet-a", CIDR: "172.18.0.0/20", AvailabilityZone: "a"},
+				{ID: "subnet-b", CIDR: "172.18.16.0/20", AvailabilityZone: "b"},
+			},
+		}
+
+		result := GetSubnetIDs(network)
+
+		assert.False(t, result.IsNull(), "subnet_ids must be populated when the API returns subnets")
+		ids := []string{}
+		for _, e := range result.Elements() {
+			ids = append(ids, e.(types.String).ValueString())
+		}
+		assert.ElementsMatch(t, []string{"subnet-a", "subnet-b"}, ids)
+	})
+
+	t.Run("a nil network returns a null set so the schema reports the attribute as absent", func(t *testing.T) {
+		result := GetSubnetIDs(nil)
+
+		assert.True(t, result.IsNull())
+	})
+
+	t.Run("a network with no subnets returns a null set", func(t *testing.T) {
+		result := GetSubnetIDs(&k8sSDK.Network{VPCID: "vpc-xyz"})
+
+		assert.True(t, result.IsNull())
+	})
+}
+
+func TestConvertNodePoolReadsSubnetIDs(t *testing.T) {
+	t.Run("a node pool's network subnets are exposed as the set of their IDs", func(t *testing.T) {
+		sdkPool := &k8sSDK.NodePool{
+			ID:   "np-id",
+			Name: "worker",
+			Network: &k8sSDK.Network{
+				VPCID: "vpc-xyz",
+				Subnets: []k8sSDK.Subnet{
+					{ID: "subnet-a", CIDR: "172.18.0.0/20", AvailabilityZone: "a"},
+					{ID: "subnet-b", CIDR: "172.18.16.0/20", AvailabilityZone: "b"},
+				},
+			},
+		}
+
+		converted := ConvertToNodePoolToTFModel(sdkPool, "br-se1")
+
+		assert.False(t, converted.SubnetIDs.IsNull())
+		ids := []string{}
+		for _, e := range converted.SubnetIDs.Elements() {
+			ids = append(ids, e.(types.String).ValueString())
+		}
+		assert.ElementsMatch(t, []string{"subnet-a", "subnet-b"}, ids)
+	})
+
+	t.Run("a node pool without network information leaves subnet_ids null", func(t *testing.T) {
+		sdkPool := &k8sSDK.NodePool{
+			ID:      "np-id",
+			Name:    "worker",
+			Network: nil,
+		}
+
+		converted := ConvertToNodePoolToTFModel(sdkPool, "br-se1")
+
+		assert.True(t, converted.SubnetIDs.IsNull())
+	})
+}
+
+func TestBuildPatchNodePoolRequest(t *testing.T) {
+	t.Run("a node pool's Kubernetes version is upgraded in place when the plan version differs from the state version", func(t *testing.T) {
+		state := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(2),
+		}}
+		plan := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.29.0"),
+			Replicas: types.Int64Value(2),
+		}}
+
+		patch := buildPatchNodePoolRequest(state, plan)
+
+		assert.NotNil(t, patch.Version)
+		assert.Equal(t, "v1.29.0", *patch.Version)
+	})
+
+	t.Run("a node pool keeps its current version when the plan version equals the state version", func(t *testing.T) {
+		state := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(2),
+		}}
+		plan := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(2),
+		}}
+
+		patch := buildPatchNodePoolRequest(state, plan)
+
+		assert.Nil(t, patch.Version, "no upgrade should be triggered when version did not change")
+	})
+
+	t.Run("a node pool keeps its current version when the plan version is unknown", func(t *testing.T) {
+		state := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(2),
+		}}
+		plan := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringUnknown(),
+			Replicas: types.Int64Value(2),
+		}}
+
+		patch := buildPatchNodePoolRequest(state, plan)
+
+		assert.Nil(t, patch.Version)
+	})
+
+	t.Run("a node pool keeps its current version when the plan version is null", func(t *testing.T) {
+		state := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(2),
+		}}
+		plan := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringNull(),
+			Replicas: types.Int64Value(2),
+		}}
+
+		patch := buildPatchNodePoolRequest(state, plan)
+
+		assert.Nil(t, patch.Version)
+	})
+
+	t.Run("a node pool's replicas are not sent in patch because they are managed by autoscaling", func(t *testing.T) {
+		state := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(2),
+		}}
+		plan := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(5),
+		}}
+
+		patch, _ := buildPatchNodePoolRequest(state, plan)
+
+		assert.Nil(t, patch.Replicas)
+	})
+
+	t.Run("a node pool can have its version updated along with autoscale bounds in the same patch", func(t *testing.T) {
+		state := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(2),
+		}}
+		plan := NodePoolResourceModel{NodePool: NodePool{
+			Version:     types.StringValue("v1.30.1"),
+			Replicas:    types.Int64Value(4),
+			MaxReplicas: types.Int64Value(10),
+			MinReplicas: types.Int64Value(2),
+		}}
+
+		patch := buildPatchNodePoolRequest(state, plan)
+
+		assert.NotNil(t, patch.Version)
+		assert.Equal(t, "v1.30.1", *patch.Version)
+		assert.Nil(t, patch.Replicas)
+		assert.NotNil(t, patch.AutoScale)
+		assert.Equal(t, 10, *patch.AutoScale.MaxReplicas)
+		assert.Equal(t, 2, *patch.AutoScale.MinReplicas)
+	})
+
+	t.Run("a node pool's autoscale bounds are carried in the patch when set in the plan", func(t *testing.T) {
+		state := NodePoolResourceModel{NodePool: NodePool{
+			Version:  types.StringValue("v1.28.0"),
+			Replicas: types.Int64Value(2),
+		}}
+		plan := NodePoolResourceModel{NodePool: NodePool{
+			Version:     types.StringValue("v1.28.0"),
+			Replicas:    types.Int64Value(2),
+			MaxReplicas: types.Int64Value(5),
+			MinReplicas: types.Int64Value(1),
+		}}
+
+		patch, _ := buildPatchNodePoolRequest(state, plan)
+
+		assert.NotNil(t, patch.AutoScale)
+		assert.NotNil(t, patch.AutoScale.MaxReplicas)
+		assert.Equal(t, 5, *patch.AutoScale.MaxReplicas)
+		assert.NotNil(t, patch.AutoScale.MinReplicas)
+		assert.Equal(t, 1, *patch.AutoScale.MinReplicas)
+	})
+}
+
+func TestConvertToNodePoolReadsVersion(t *testing.T) {
+	t.Run("a node pool's current Kubernetes version is exposed when the API returns it", func(t *testing.T) {
+		version := "v1.30.1"
+		sdkPool := &k8sSDK.NodePool{
+			ID:      "np-id",
+			Name:    "worker",
+			Version: &version,
+		}
+
+		converted := ConvertToNodePoolToTFModel(sdkPool, "br-se1")
+
+		assert.Equal(t, types.StringValue("v1.30.1"), converted.Version)
+	})
+
+	t.Run("a node pool without version information leaves the version field null", func(t *testing.T) {
+		sdkPool := &k8sSDK.NodePool{
+			ID:      "np-id",
+			Name:    "worker",
+			Version: nil,
+		}
+
+		converted := ConvertToNodePoolToTFModel(sdkPool, "br-se1")
+
+		assert.True(t, converted.Version.IsNull())
+	})
+}
+
+func TestNodePoolSchemaVersionPlanModifiers(t *testing.T) {
+	r := &NewNodePoolResource{}
+	resp := &resource.SchemaResponse{}
+
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+
+	t.Run("the version attribute is exposed so users can declare the node pool's Kubernetes version", func(t *testing.T) {
+		_, ok := resp.Schema.Attributes["version"]
+		assert.True(t, ok, "version attribute must be present on the schema")
+	})
+
+	t.Run("the version attribute is optional and computed so the provider can echo back the server value", func(t *testing.T) {
+		attrRaw, ok := resp.Schema.Attributes["version"].(schema.StringAttribute)
+		assert.True(t, ok)
+		assert.True(t, attrRaw.Optional)
+		assert.True(t, attrRaw.Computed)
+	})
+
+	t.Run("changing the version must trigger an in-place upgrade, never a replacement of the node pool", func(t *testing.T) {
+		attrRaw, ok := resp.Schema.Attributes["version"].(schema.StringAttribute)
+		assert.True(t, ok)
+
+		hasUseStateForUnknown := false
+		hasRequiresReplace := false
+		for _, modifier := range attrRaw.PlanModifiers {
+			if reflect.TypeOf(modifier) == reflect.TypeOf(stringplanmodifier.UseStateForUnknown()) {
+				hasUseStateForUnknown = true
+			}
+			if reflect.TypeOf(modifier) == reflect.TypeOf(stringplanmodifier.RequiresReplace()) {
+				hasRequiresReplace = true
+			}
+		}
+
+		assert.True(t, hasUseStateForUnknown, "version must use state for unknown to avoid spurious diffs on read")
+		assert.False(t, hasRequiresReplace, "version change is upgraded in place, not by recreating the node pool")
+	})
+}
+
+func TestNodePoolImportState(t *testing.T) {
+	ctx := context.Background()
+	r := &NewNodePoolResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	npSchema := schemaResp.Schema
+
+	newImportResp := func() *resource.ImportStateResponse {
+		return &resource.ImportStateResponse{
+			State: tfsdk.State{
+				Schema: npSchema,
+				Raw:    tftypes.NewValue(npSchema.Type().TerraformType(ctx), nil),
+			},
+		}
+	}
+
+	t.Run("a node pool import id missing the comma separator is rejected with an explanatory error", func(t *testing.T) {
+		resp := newImportResp()
+		r.ImportState(ctx, resource.ImportStateRequest{ID: "single-id-no-comma"}, resp)
+
+		assert.True(t, resp.Diagnostics.HasError(), "import id without comma must be rejected")
+		assert.Contains(t, resp.Diagnostics.Errors()[0].Detail(), "cluster_id,node_pool_id",
+			"the error must teach the user the expected import id format")
+	})
+
+	t.Run("a valid 'cluster_id,node_pool_id' import id puts both values into state", func(t *testing.T) {
+		resp := newImportResp()
+		r.ImportState(ctx, resource.ImportStateRequest{ID: "cluster-uuid,np-uuid"}, resp)
+
+		assert.False(t, resp.Diagnostics.HasError(), "valid import must not error: %v", resp.Diagnostics)
+
+		var clusterID types.String
+		resp.State.GetAttribute(ctx, path.Root("cluster_id"), &clusterID)
+		assert.Equal(t, types.StringValue("cluster-uuid"), clusterID)
+
+		var npID types.String
+		resp.State.GetAttribute(ctx, path.Root("id"), &npID)
+		assert.Equal(t, types.StringValue("np-uuid"), npID)
+	})
+}
+
+func TestNodePoolConfigValidators(t *testing.T) {
+	r := &NewNodePoolResource{}
+	validators := r.ConfigValidators(context.Background())
+
+	t.Run("a nodepool declares config validators so subnet_ids and availability_zones cannot be set together", func(t *testing.T) {
+		assert.Len(t, validators, 1, "expected exactly one config validator")
+	})
+
+	t.Run("the validator description names both conflicting attributes so the user knows what to remove", func(t *testing.T) {
+		desc := validators[0].Description(context.Background())
+		assert.Contains(t, desc, "subnet_ids")
+		assert.Contains(t, desc, "availability_zones")
 	})
 }
 

--- a/mgc/utils/converters.go
+++ b/mgc/utils/converters.go
@@ -175,3 +175,29 @@ func StringSliceToTypesList(slice []string) types.List {
 	listValue, _ := types.ListValue(types.StringType, elements)
 	return listValue
 }
+
+func ConvertTypeSetToArray[T any](set types.Set, extract func(attr.Value) (T, bool)) *[]T {
+	elements := set.Elements()
+	if len(elements) < 1 {
+		return nil
+	}
+
+	result := make([]T, 0, len(elements))
+	for _, e := range elements {
+		if v, ok := extract(e); ok {
+			result = append(result, v)
+		}
+	}
+
+	return &result
+}
+
+func ConvertTypeSetToStringArray(set types.Set) *[]string {
+	return ConvertTypeSetToArray(set, func(v attr.Value) (string, bool) {
+		i, ok := v.(types.String)
+		if !ok {
+			return "", false
+		}
+		return i.ValueString(), true
+	})
+}


### PR DESCRIPTION
## What does this PR do?
Adiciona suporte para configuração customizada de subnets (VPC) e
upgrade in-place de versão do Kubernetes em clusters e nodepools.

Mudanças:
- Adiciona atributo `subnet_ids` em recursos e datasources de cluster
  e nodepool, substituindo `cidr`, `network_name` e `subnet_id` no
  datasource de cluster.
- `subnet_ids` é mutuamente exclusivo com `availability_zones` no
  nodepool (que passa a ser deprecated).
- Permite alterar o atributo `version` em cluster e nodepool sem
  recriar o recurso, disparando upgrade via PATCH na API.
- `description` do cluster passa a ser atualizável in-place.
- Corrige possível panic em `convertToKubernetesCluster` quando a
  API retorna `Region` nulo.
- Helpers compartilhados (`GetSubnetIDs`, `CreateKubernetesSDKNetworkRequest`,
  `ResourceSubnetIDsAttribute`, `DatasourceSubnetIDsAttribute`) em `common.go`.
- Novo utilitário genérico `ConvertTypeSetToArray` em `mgc/utils`.

## How Has This Been Tested?
Testes unitários e executados localmente. 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
