### PR TITLE
Fix: Normaliza campos vazios do certificado TLS para null

### DIFF
--- a/mgc/lbaas/resource_network.go
+++ b/mgc/lbaas/resource_network.go
@@ -379,6 +379,9 @@ func (r *LoadBalancerResource) Schema(_ context.Context, _ resource.SchemaReques
 						"id": schema.StringAttribute{
 							Description: "The unique identifier of the listener.",
 							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"backend_name": schema.StringAttribute{
 							Description: "The name of the backend associated with this listener.",
@@ -428,6 +431,7 @@ func (r *LoadBalancerResource) Schema(_ context.Context, _ resource.SchemaReques
 							},
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
+								utils.StringNullIfEmptyModifier(),
 							},
 						},
 					},

--- a/mgc/utils/planmodifiers.go
+++ b/mgc/utils/planmodifiers.go
@@ -283,3 +283,23 @@ func (m setRequiresReplaceOnChange) PlanModifySet(ctx context.Context, req planm
 	// If we reach here, the sets have the same membership
 	resp.RequiresReplace = false
 }
+
+type stringNullIfEmptyModifier struct{}
+
+func StringNullIfEmptyModifier() planmodifier.String {
+	return stringNullIfEmptyModifier{}
+}
+
+func (stringNullIfEmptyModifier) Description(_ context.Context) string {
+	return "Treats an empty string value as null."
+}
+
+func (m stringNullIfEmptyModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (stringNullIfEmptyModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() && req.ConfigValue.ValueString() == "" {
+		resp.PlanValue = types.StringNull()
+	}
+}

--- a/mgc/utils/planmodifiers_test.go
+++ b/mgc/utils/planmodifiers_test.go
@@ -666,3 +666,66 @@ func TestSetRequiresReplaceOnChangeEdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestStringNullIfEmpty(t *testing.T) {
+	tests := []struct {
+		name              string
+		configValue       types.String
+		planValue         types.String
+		expectedPlanValue types.String
+	}{
+		{
+			name:              "empty string becomes null",
+			configValue:       types.StringValue(""),
+			planValue:         types.StringValue(""),
+			expectedPlanValue: types.StringNull(),
+		},
+		{
+			name:              "non-empty string unchanged",
+			configValue:       types.StringValue("my-cert"),
+			planValue:         types.StringValue("my-cert"),
+			expectedPlanValue: types.StringValue("my-cert"),
+		},
+		{
+			name:              "null config unchanged",
+			configValue:       types.StringNull(),
+			planValue:         types.StringNull(),
+			expectedPlanValue: types.StringNull(),
+		},
+		{
+			name:              "unknown config unchanged",
+			configValue:       types.StringUnknown(),
+			planValue:         types.StringUnknown(),
+			expectedPlanValue: types.StringUnknown(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modifier := StringNullIfEmptyModifier()
+			req := planmodifier.StringRequest{
+				ConfigValue: tt.configValue,
+				PlanValue:   tt.planValue,
+			}
+			resp := &planmodifier.StringResponse{
+				PlanValue: tt.planValue,
+			}
+
+			modifier.PlanModifyString(context.Background(), req, resp)
+
+			assert.True(t, resp.PlanValue.Equal(tt.expectedPlanValue),
+				"PlanValue = %v, want %v", resp.PlanValue, tt.expectedPlanValue)
+		})
+	}
+}
+
+func TestStringNullIfEmpty_Description(t *testing.T) {
+	modifier := StringNullIfEmptyModifier()
+	expected := "Treats an empty string value as null."
+	assert.Equal(t, expected, modifier.Description(context.Background()))
+	assert.Equal(t, expected, modifier.MarkdownDescription(context.Background()))
+}
+
+func TestStringNullIfEmpty_IntegrationWithFramework(t *testing.T) {
+	var _ planmodifier.String = StringNullIfEmptyModifier()
+}


### PR DESCRIPTION
Contexto / problema
No recurso de Load Balancer ([mgc/lbaas/resource_network.go](vscode-webview://0popokupf7f108tl5rjpbdo628f794cao0f2ktlqtfbpu6tnrnir/mgc/lbaas/resource_network.go)), o campo tls_certificate_name dos listeners apresentava inconsistência entre o valor declarado pelo usuário e o estado retornado pela API: quando o usuário definia tls_certificate_name = "" (string vazia), a API tratava isso como ausência de certificado e retornava null, gerando erro na criação e drift permanente no plano do Terraform e/ou exigindo replace indevido do listener.

O que foi feito
Foi adicionado o StringNullIfEmptyModifier, um planmodifier.String reutilizável que normaliza strings vazias ("") para null durante a fase de planejamento. Se o ConfigValue for uma string vazia (não nula e não desconhecida), o PlanValue é forçado para types.StringNull(), alinhando o plano com o que a API efetivamente persiste.

Resultado
Usuários podem declarar tls_certificate_name = "" ou omitir, o comportamento será o mesmo. O modifier também fica disponível como utilitário genérico para outros recursos que sofram do mesmo padrão de normalização vazio/null.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
