### PR TITLE
Configurando o parametro version no nodepool resource para apenas leitura

### DIFF
--- a/docs/resources/kubernetes_nodepool.md
+++ b/docs/resources/kubernetes_nodepool.md
@@ -44,7 +44,6 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
 							The subnets must belong to the same VPC.
 							This field cannot be changed after the node pool is created
 - `taints` (Attributes List) Property associating a set of nodes. (see [below for nested schema](#nestedatt--taints))
-- `version` (String) The native Kubernetes version of the node pool. Use the standard "vX.Y.Z" format.
 
 ### Read-Only
 
@@ -53,6 +52,7 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
 - `labels` (Map of String) Map of labels for the node pool.
 - `security_groups` (Set of String) List of security groups for the node pool.
 - `updated_at` (String) Date of the last change to the Kubernetes Node.
+- `version` (String) The native Kubernetes version of the node pool. Use the standard "vX.Y.Z" format.
 
 <a id="nestedatt--taints"></a>
 ### Nested Schema for `taints`

--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -186,10 +186,9 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 			},
 			"version": schema.StringAttribute{
 				Description: "The native Kubernetes version of the node pool. Use the standard \"vX.Y.Z\" format.",
-				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			//deprecated


### PR DESCRIPTION

## What does this PR do?
Altera o campo `version` do `resource_nodepool` para read-only


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
