### PR TITLE
vpc-routes adjusts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MagaluCloud/terraform-provider-mgc
 go 1.25.3
 
 require (
-	github.com/MagaluCloud/mgc-sdk-go v1.9.0
+	github.com/MagaluCloud/mgc-sdk-go v1.12.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/MagaluCloud/mgc-sdk-go v1.8.1 h1:FFvNJA5QW/XyAP0gRn5JYznLrBPJzngjdR/I
 github.com/MagaluCloud/mgc-sdk-go v1.8.1/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
 github.com/MagaluCloud/mgc-sdk-go v1.9.0 h1:+IJwm5c6RG1SH5/Nj0QJIUCkemolqCdrRb/4lJwirQU=
 github.com/MagaluCloud/mgc-sdk-go v1.9.0/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
+github.com/MagaluCloud/mgc-sdk-go v1.12.0 h1:9qilLBhkHTbz+NnAXgV7VyH2PJiI3HkQKIOx5LSNEYQ=
+github.com/MagaluCloud/mgc-sdk-go v1.12.0/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/mgc/network/datasource_vpcsroutes.go
+++ b/mgc/network/datasource_vpcsroutes.go
@@ -128,11 +128,7 @@ func convertSDKListRouteResultToTerraformNetworkListVpcsRouteModel(sdkResult *ne
 		Status:          types.StringValue(string(sdkResult.Status)),
 	}
 
-	var description *string
-	if sdkResult.Description != "" {
-		description = &sdkResult.Description
-	}
-	tfModel.Description = types.StringPointerValue(description)
+	tfModel.Description = types.StringValue(sdkResult.Description)
 
 	return tfModel
 }

--- a/mgc/network/resource_vpcsroutes.go
+++ b/mgc/network/resource_vpcsroutes.go
@@ -69,9 +69,6 @@ func (r *NetworkVpcsRouteResource) Schema(_ context.Context, _ resource.SchemaRe
 			"id": schema.StringAttribute{
 				Description: "The ID of the route.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"vpc_id": schema.StringAttribute{
 				Description: "ID of the VPC where this route is associated.",
@@ -97,30 +94,23 @@ func (r *NetworkVpcsRouteResource) Schema(_ context.Context, _ resource.SchemaRe
 			"description": schema.StringAttribute{
 				Description: "The description to help identify the route.",
 				Optional:    true,
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"next_hop": schema.StringAttribute{
 				Description: "Resolved next hop for the route, derived from the associated port.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"type": schema.StringAttribute{
 				Description: "Type of the route, as defined by the networking service.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"status": schema.StringAttribute{
 				Description: "Current status of the route.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 		},
 	}
@@ -145,7 +135,7 @@ func (r *NetworkVpcsRouteResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	route, err := r.WaitUntilRouteSatusMatches(ctx, vpcID, createdRoute.ID, string(netSDK.RouteStatusCreated))
+	route, err := r.WaitUntilRouteStatusMatches(ctx, vpcID, createdRoute.ID, string(netSDK.RouteStatusCreated))
 	if err != nil {
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))
 		data.ID = types.StringValue(createdRoute.ID)
@@ -166,6 +156,10 @@ func (r *NetworkVpcsRouteResource) Read(ctx context.Context, req resource.ReadRe
 
 	route, err := r.networkRoute.Get(ctx, data.VpcID.ValueString(), data.ID.ValueString())
 	if err != nil {
+		if httpErr, ok := err.(*clientSDK.HTTPError); ok && httpErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))
 		return
 	}
@@ -187,11 +181,14 @@ func (r *NetworkVpcsRouteResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	_, err = r.WaitUntilRouteSatusMatches(ctx, data.ID.ValueString(), string(netSDK.RouteStatusDeleted))
+	_, err = r.WaitUntilRouteStatusMatches(ctx, data.VpcID.ValueString(), data.ID.ValueString(), string(netSDK.RouteStatusDeleted))
 	if err != nil {
 		switch e := err.(type) {
 		case *clientSDK.HTTPError:
 			if e.StatusCode == http.StatusNotFound {
+				return
+			} else {
+				resp.Diagnostics.AddError(utils.ParseSDKError(err))
 				return
 			}
 		default:
@@ -220,13 +217,12 @@ func (r *NetworkVpcsRouteResource) ImportState(ctx context.Context, req resource
 	)
 }
 
-func (r *NetworkVpcsRouteResource) WaitUntilRouteSatusMatches(ctx context.Context, vpcID, routeID string, expectedStatus ...string) (*netSDK.VpcsRoute, error) {
+func (r *NetworkVpcsRouteResource) WaitUntilRouteStatusMatches(ctx context.Context, vpcID, routeID string, expectedStatus ...string) (*netSDK.VpcsRoute, error) {
 	var result *netSDK.VpcsRoute
 	var err error
 
+	time.Sleep(5 * time.Second)
 	for startTime := time.Now(); time.Since(startTime) < RoutePoolingTimeout; {
-		time.Sleep(1 * time.Minute)
-
 		result, err = r.networkRoute.Get(ctx, vpcID, routeID)
 		if err != nil {
 			return nil, err
@@ -242,6 +238,7 @@ func (r *NetworkVpcsRouteResource) WaitUntilRouteSatusMatches(ctx context.Contex
 		}
 
 		tflog.Debug(ctx, fmt.Sprintf("current route status: [%s]", status))
+		time.Sleep(30 * time.Second)
 	}
 
 	return result, errors.New("timeout waiting for route to provision")
@@ -261,12 +258,7 @@ func convertSDKRouteResultToTerraformNetworkVpcsRouteModel(sdkResult *netSDK.Vpc
 		Type:            types.StringValue(sdkResult.Type),
 		Status:          types.StringValue(string(sdkResult.Status)),
 	}
-
-	var description *string
-	if sdkResult.Description != "" {
-		description = &sdkResult.Description
-	}
-	tfModel.Description = types.StringPointerValue(description)
+	tfModel.Description = types.StringValue(sdkResult.Description)
 
 	return tfModel
 }

--- a/mgc/network/resource_vpcsroutes.go
+++ b/mgc/network/resource_vpcsroutes.go
@@ -138,8 +138,9 @@ func (r *NetworkVpcsRouteResource) Create(ctx context.Context, req resource.Crea
 	route, err := r.WaitUntilRouteStatusMatches(ctx, vpcID, createdRoute.ID, string(netSDK.RouteStatusCreated))
 	if err != nil {
 		resp.Diagnostics.AddError(utils.ParseSDKError(err))
-		data.ID = types.StringValue(createdRoute.ID)
-		resp.State.Set(ctx, &data)
+		if fetched, getErr := r.networkRoute.Get(ctx, vpcID, createdRoute.ID); getErr == nil && fetched != nil {
+			resp.Diagnostics.Append(resp.State.Set(ctx, convertSDKRouteResultToTerraformNetworkVpcsRouteModel(fetched))...)
+		}
 		return
 	}
 


### PR DESCRIPTION
## What does this PR do?

Ajustes sugeridos para a branch feat/vpc-routes. 


Pontos de melhorias observados e modificados: 

- Atributos readonly não necessitam de requiresReplace()
- Switch no Delete ignorando erros não-404
- Polling alto
- Typo no nome do método: WaitUntilRouteSatusMatches
- Em caso de erro/indisponibilidade da API, o create salvava o estado atual (com atributos unknown, o que pode implicar na necessidade de um import manual do usuário) 

Correção de bugs encontrados e corrigidos: 

- Criar recurso com description vazio (“”)
<img width="990" height="175" alt="Captura de tela de 2026-05-17 12-11-52" src="https://github.com/user-attachments/assets/faa67f98-90de-4fa6-962f-2a0cb0b243e7" />

- Após um erro no Delete, o state ficava com um ID que não existia, gerando um lock no terraform. 

        
        Planning failed. OpenTofu encountered an error while generating this plan.
        ╷
        │ Error: API request failed with HTTP error
        │ 
        │   with mgc_network_vpcs_route.route_primary,
        │   on main.tf line 21, in resource "mgc_network_vpcs_route" "route_primary":
        │   21: resource "mgc_network_vpcs_route" "route_primary" {
        │ 
        │ HTTP Error:
        │   Status: 404 Not Found
        │   Body: {"type":"about:blank","title":"Not Found","status":404,"detail":"Route '0f275049-d993-4a2f-84e0-3b111c3b8baa' not found in VPC '9d4eee75-161f-4a99-aed4-a39cc789e68b'","resource_id":"0f275049-d993-4a2f-84e0-3b111c3b8baa","instance":"/v1/vpcs/9d4eee75-161f-4a99-aed4-a39cc789e68b/route_table/routes/0f275049-d993-4a2f-84e0-3b111c3b8baa"}
        │   URL: https://api.magalu.cloud/br-se1/network/v1/vpcs/9d4eee75-161f-4a99-aed4-a39cc789e68b/route_table/routes/0f275049-d993-4a2f-84e0-3b111c3b8baa
        │   Request ID: 244a7646-d312-4016-8212-427d14c9465b
        │   MGC Trace ID: 88ec9921-3ed7-467f-bdaf-5aadcd0c1176




