### PR TITLE
feat: update nodepool flavor without recreate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MagaluCloud/terraform-provider-mgc
 go 1.25.3
 
 require (
-	github.com/MagaluCloud/mgc-sdk-go v1.12.0
+	github.com/MagaluCloud/mgc-sdk-go v1.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,5 @@
-github.com/MagaluCloud/mgc-sdk-go v1.5.0 h1:tcOt4/LdpSCDCGqVphveIaGbg5Q2FzAN5BFZIiVyjRA=
-github.com/MagaluCloud/mgc-sdk-go v1.5.0/go.mod h1:kNVX4v1CBlkIcKxnzNcQ0jgs5Awu3Vk0Bd+vaG7GvUs=
-github.com/MagaluCloud/mgc-sdk-go v1.8.0 h1:Zl3BxceMyibssTKgWmv+hP3y0tzdKgISHfqMFeB7HVE=
-github.com/MagaluCloud/mgc-sdk-go v1.8.0/go.mod h1:kNVX4v1CBlkIcKxnzNcQ0jgs5Awu3Vk0Bd+vaG7GvUs=
-github.com/MagaluCloud/mgc-sdk-go v1.8.1 h1:FFvNJA5QW/XyAP0gRn5JYznLrBPJzngjdR/Iba/+wE4=
-github.com/MagaluCloud/mgc-sdk-go v1.8.1/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
-github.com/MagaluCloud/mgc-sdk-go v1.9.0 h1:+IJwm5c6RG1SH5/Nj0QJIUCkemolqCdrRb/4lJwirQU=
-github.com/MagaluCloud/mgc-sdk-go v1.9.0/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
-github.com/MagaluCloud/mgc-sdk-go v1.12.0 h1:9qilLBhkHTbz+NnAXgV7VyH2PJiI3HkQKIOx5LSNEYQ=
-github.com/MagaluCloud/mgc-sdk-go v1.12.0/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
+github.com/MagaluCloud/mgc-sdk-go v1.13.0 h1:Z3d6rk8z0GhqXY2pxamFNSw0dRgT7Q5VuMJDyEwrF/I=
+github.com/MagaluCloud/mgc-sdk-go v1.13.0/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -39,8 +31,6 @@ github.com/hashicorp/go-plugin v1.6.3 h1:xgHB+ZUSYeuJi96WtxEjzi23uh7YQpznjGh0U0U
 github.com/hashicorp/go-plugin v1.6.3/go.mod h1:MRobyh+Wc/nYy1V4KAXUiYfzxoYhs7V1mlH1Z7iY2h0=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/terraform-plugin-framework v1.15.0 h1:LQ2rsOfmDLxcn5EeIwdXFtr03FVsNktbbBci8cOKdb4=
-github.com/hashicorp/terraform-plugin-framework v1.15.0/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
 github.com/hashicorp/terraform-plugin-framework v1.15.1 h1:2mKDkwb8rlx/tvJTlIcpw0ykcmvdWv+4gY3SIgk8Pq8=
 github.com/hashicorp/terraform-plugin-framework v1.15.1/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
 github.com/hashicorp/terraform-plugin-framework-validators v0.18.0 h1:OQnlOt98ua//rCw+QhBbSqfW3QbwtVrcdWeQN5gI3Hw=

--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -89,9 +89,6 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 			"flavor_name": schema.StringAttribute{
 				Description: "Definition of the CPU, RAM, and storage capacity of the nodes.",
 				Required:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"cluster_id": schema.StringAttribute{
 				Description: "UUID of the Kubernetes cluster.",
@@ -359,7 +356,11 @@ func (r *NewNodePoolResource) Update(ctx context.Context, req resource.UpdateReq
 }
 
 func buildPatchNodePoolRequest(plan NodePoolResourceModel) k8sSDK.PatchNodePoolRequest {
-	patch := k8sSDK.PatchNodePoolRequest{}
+	flavor := plan.Flavor.ValueString()
+
+	patch := k8sSDK.PatchNodePoolRequest{
+		Flavor: &flavor,
+	}
 	if !plan.MaxReplicas.IsUnknown() || !plan.MinReplicas.IsUnknown() {
 		patch.AutoScale = &k8sSDK.AutoScale{}
 	}

--- a/mgc/kubernetes/resource_nodepool_test.go
+++ b/mgc/kubernetes/resource_nodepool_test.go
@@ -210,6 +210,7 @@ func TestBuildPatchNodePoolRequest(t *testing.T) {
 			Replicas:    types.Int64Value(2),
 			MaxReplicas: types.Int64Value(5),
 			MinReplicas: types.Int64Value(1),
+			Flavor:      types.StringValue("BV2-4-40"),
 		}}
 
 		patch := buildPatchNodePoolRequest(plan)
@@ -219,6 +220,7 @@ func TestBuildPatchNodePoolRequest(t *testing.T) {
 		assert.Equal(t, 5, *patch.AutoScale.MaxReplicas)
 		assert.NotNil(t, patch.AutoScale.MinReplicas)
 		assert.Equal(t, 1, *patch.AutoScale.MinReplicas)
+		assert.Equal(t, "BV2-4-40", *patch.Flavor)
 	})
 }
 


### PR DESCRIPTION
## What does this PR do?
- Atualizado o update do recurso `mgc_kubernetes_nodepool` para ser possível atualizar o flavor do nodepool sem a necessidade de recriar ele.

## How Has This Been Tested?
- Executado o comando de atualizado e validado o state

<img width="1156" height="248" alt="image" src="https://github.com/user-attachments/assets/adea76d5-104a-44bf-86b7-bd3dc67c5dca" />


## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
