### PR TITLE
fix: use req.Plan instead of req.Config in Create methods

### DIFF
--- a/mgc/database/resource_clusters.go
+++ b/mgc/database/resource_clusters.go
@@ -326,7 +326,7 @@ func (r *DBaaSClusterResource) Schema(_ context.Context, _ resource.SchemaReques
 
 func (r *DBaaSClusterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan DBaaSClusterModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/mgc/database/resource_instances.go
+++ b/mgc/database/resource_instances.go
@@ -303,7 +303,7 @@ func (r *DBaaSInstanceResource) Schema(_ context.Context, _ resource.SchemaReque
 
 func (r *DBaaSInstanceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data DBaaSInstanceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/mgc/database/resource_parametergroups.go
+++ b/mgc/database/resource_parametergroups.go
@@ -95,7 +95,7 @@ func (r *DBaaSParameterGroupsResource) Schema(_ context.Context, _ resource.Sche
 
 func (r *DBaaSParameterGroupsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data DBaaSParametersModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/mgc/database/resource_parameters.go
+++ b/mgc/database/resource_parameters.go
@@ -77,7 +77,7 @@ func (r *DBaaSParameterResource) Schema(_ context.Context, _ resource.SchemaRequ
 
 func (r *DBaaSParameterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data DBaaSParameterModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/mgc/kubernetes/resource_cluster.go
+++ b/mgc/kubernetes/resource_cluster.go
@@ -202,7 +202,7 @@ func (r *k8sClusterResource) Read(ctx context.Context, req resource.ReadRequest,
 
 func (r *k8sClusterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data KubernetesClusterCreateResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -258,7 +258,7 @@ func (r *NewNodePoolResource) Read(ctx context.Context, req resource.ReadRequest
 
 func (r *NewNodePoolResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data NodePoolResourceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/mgc/lbaas/resource_network.go
+++ b/mgc/lbaas/resource_network.go
@@ -497,7 +497,7 @@ func (r *LoadBalancerResource) Schema(_ context.Context, _ resource.SchemaReques
 
 func (r *LoadBalancerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data LoadBalancerModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/mgc/network/resource_natgateway.go
+++ b/mgc/network/resource_natgateway.go
@@ -99,7 +99,7 @@ func (r *natGatewayResource) Configure(_ context.Context, req resource.Configure
 
 func (r *natGatewayResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan natGatewayResourceModel
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/mgc/network/resource_vpcsinterfaces.go
+++ b/mgc/network/resource_vpcsinterfaces.go
@@ -138,7 +138,7 @@ func (r *NetworkVPCInterfaceResource) Read(ctx context.Context, req resource.Rea
 
 func (r *NetworkVPCInterfaceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var model NetworkVPCInterfaceModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &model)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &model)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/mgc/virtualmachines/resource_instances.go
+++ b/mgc/virtualmachines/resource_instances.go
@@ -371,7 +371,7 @@ func (r *vmInstances) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 func (r *vmInstances) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	state := vmInstancesResourceModel{}
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
Align with the official Terraform Plugin Framework example which reads resource data from req.Plan instead of req.Config.

Reference: https://developer.hashicorp.com/terraform/plugin/framework/resources/create
Define Create Method section:
- "Most use cases should access the plan data in the resource.CreateRequest.Plan field."
- "Get request data from the Terraform plan data over configuration data as the schema or resource may include plan modification logic which sets plan values."

## What does this PR do?

Replace `req.Config.Get()` with `req.Plan.Get()` in the Create method of all resources. The official Terraform Plugin Framework documentation recommends accessing the plan data over configuration data, as the schema or resource may include plan modification logic which sets plan values.

## How Has This Been Tested?

- `make before-commit` passes (lint, formatting, doc generation, tests)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Observation
 - All 10 changes are safe. None of these resources have logic requiring req.Config (such as explicitly checking what the user set vs what was defaulted). The only file with an actual schema Default (resource_vpcsinterfaces.go) already has its own manual fallback that converges to the same result.
