### PR TITLE
fix: preserve previous state values on API errors in Object Bucket Read

### DIFF
--- a/mgc/objects/resource_buckets.go
+++ b/mgc/objects/resource_buckets.go
@@ -303,59 +303,59 @@ func (r *objectStorageBuckets) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	lockStatus, err := r.buckets.GetBucketLockStatus(ctx, bucketName)
-	if err != nil {
-		state.Lock = types.BoolValue(false)
-	} else {
+	if err == nil {
 		state.Lock = types.BoolValue(lockStatus)
 	}
 
 	policy, err := r.buckets.GetPolicy(ctx, bucketName)
-	if err != nil {
-		state.Policy = types.StringValue("")
-	} else if policy != nil {
-		policyJSON, err := json.Marshal(policy)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error serializing bucket policy",
-				fmt.Sprintf("Could not serialize policy for bucket %s: %s", bucketName, err.Error()),
-			)
-			return
+	if err == nil {
+		if policy != nil {
+			policyJSON, err := json.Marshal(policy)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error serializing bucket policy",
+					fmt.Sprintf("Could not serialize policy for bucket %s: %s", bucketName, err.Error()),
+				)
+				return
+			}
+			state.Policy = types.StringValue(string(policyJSON))
+		} else {
+			state.Policy = types.StringValue("")
 		}
-		state.Policy = types.StringValue(string(policyJSON))
-	} else {
-		state.Policy = types.StringValue("")
 	}
 
 	corsConfig, err := r.buckets.GetCORS(ctx, bucketName)
-	if err != nil || corsConfig == nil || len(corsConfig.CORSRules) == 0 {
-		state.CORS = types.ObjectNull(map[string]attr.Type{
-			"allowed_headers": types.ListType{ElemType: types.StringType},
-			"allowed_methods": types.ListType{ElemType: types.StringType},
-			"allowed_origins": types.ListType{ElemType: types.StringType},
-			"expose_headers":  types.ListType{ElemType: types.StringType},
-			"max_age_seconds": types.Int64Type,
-		})
-	} else {
-		tfCORS, err := convertFromCORSConfiguration(ctx, corsConfig)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error converting CORS configuration",
-				fmt.Sprintf("Could not convert CORS configuration: %s", err.Error()),
-			)
-			return
+	if err == nil {
+		if corsConfig == nil || len(corsConfig.CORSRules) == 0 {
+			state.CORS = types.ObjectNull(map[string]attr.Type{
+				"allowed_headers": types.ListType{ElemType: types.StringType},
+				"allowed_methods": types.ListType{ElemType: types.StringType},
+				"allowed_origins": types.ListType{ElemType: types.StringType},
+				"expose_headers":  types.ListType{ElemType: types.StringType},
+				"max_age_seconds": types.Int64Type,
+			})
+		} else {
+			tfCORS, err := convertFromCORSConfiguration(ctx, corsConfig)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error converting CORS configuration",
+					fmt.Sprintf("Could not convert CORS configuration: %s", err.Error()),
+				)
+				return
+			}
+			corsObj, diag := types.ObjectValueFrom(ctx, map[string]attr.Type{
+				"allowed_headers": types.ListType{ElemType: types.StringType},
+				"allowed_methods": types.ListType{ElemType: types.StringType},
+				"allowed_origins": types.ListType{ElemType: types.StringType},
+				"expose_headers":  types.ListType{ElemType: types.StringType},
+				"max_age_seconds": types.Int64Type,
+			}, tfCORS)
+			if diag.HasError() {
+				resp.Diagnostics.Append(diag...)
+				return
+			}
+			state.CORS = corsObj
 		}
-		corsObj, diag := types.ObjectValueFrom(ctx, map[string]attr.Type{
-			"allowed_headers": types.ListType{ElemType: types.StringType},
-			"allowed_methods": types.ListType{ElemType: types.StringType},
-			"allowed_origins": types.ListType{ElemType: types.StringType},
-			"expose_headers":  types.ListType{ElemType: types.StringType},
-			"max_age_seconds": types.Int64Type,
-		}, tfCORS)
-		if diag.HasError() {
-			resp.Diagnostics.Append(diag...)
-			return
-		}
-		state.CORS = corsObj
 	}
 
 	state.Region = types.StringValue(r.region)


### PR DESCRIPTION
Preserve prior state values when ancillary API calls (GetBucketLockStatus, GetPolicy, GetCORS) fail during Read, instead of silently overwriting them with zero values.

Reference: https://developer.hashicorp.com/terraform/plugin/framework/resources/read

## What does this PR do?

In `resource_buckets.go`, 3 API calls in the Read method were overwriting state with zero/default values on error:

- `GetBucketLockStatus` → was setting `state.Lock = false`
- `GetPolicy` → was setting `state.Policy = ""`
- `GetCORS` → was setting `state.CORS = ObjectNull(...)`

These now only update state when the API call succeeds, preserving the prior state on failure. This aligns with the Plugin Framework caveat: "Any response errors will cause Terraform to keep the prior resource state."

## How Has This Been Tested?

- `make before-commit` passes (lint, formatting, doc generation, tests)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works