### PR TITLE
fix: timeout when provisioning k8s clusters

### DIFF
--- a/mgc/kubernetes/resource_cluster.go
+++ b/mgc/kubernetes/resource_cluster.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	ClusterPoolingTimeout = 100 * time.Minute
+	ClusterPoolingTimeout = 160 * time.Minute
 )
 
 type KubernetesClusterCreateResourceModel struct {


### PR DESCRIPTION
## What does this PR do?
Increase the Kubernetes cluster pooling timeout to two and a half hours

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
