### PR TITLE
feat: Add support for labels when creating nodepools

### DIFF
--- a/docs/resources/kubernetes_nodepool.md
+++ b/docs/resources/kubernetes_nodepool.md
@@ -23,6 +23,8 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
   version      = mgc_kubernetes_cluster.cluster_with_nodepool.version
 
   # Optional labels, set only at creation. Changing them recreates the node pool.
+  # To remove every label, set `labels = {}`. Deleting the block keeps the labels
+  # already in state.
   labels = {
     environment = "staging"
     team        = "devX"
@@ -44,7 +46,7 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
 ### Optional
 
 - `availability_zones` (Set of String, Deprecated) List of availability zones where the node pool is deployed is **deprecated**, use subnet_ids instead.
-- `labels` (Map of String) Map of labels to attach to the node pool, as customizable key/value pairs. Optional and only used at creation; changing it after the node pool exists forces a new node pool.
+- `labels` (Map of String) Map of labels to attach to the node pool, as customizable key/value pairs. Optional and only used at creation; changing it after the node pool exists forces a new node pool. To remove every label, set `labels = {}` explicitly: removing the attribute from the configuration keeps the labels already recorded in state, because the value is computed whenever it is not configured.
 - `max_pods_per_node` (Number) Maximum number of pods per node.
 - `max_replicas` (Number) Maximum number of replicas for autoscaling.
 - `min_replicas` (Number) Minimum number of replicas for autoscaling.

--- a/docs/resources/kubernetes_nodepool.md
+++ b/docs/resources/kubernetes_nodepool.md
@@ -21,6 +21,13 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
   min_replicas = 1
   max_replicas = 5
   version      = mgc_kubernetes_cluster.cluster_with_nodepool.version
+
+  # Optional labels, set only at creation. Changing them recreates the node pool.
+  labels = {
+    environment = "staging"
+    team        = "devX"
+    tier        = "backend"
+  }
 }
 ```
 
@@ -37,6 +44,7 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
 ### Optional
 
 - `availability_zones` (Set of String, Deprecated) List of availability zones where the node pool is deployed is **deprecated**, use subnet_ids instead.
+- `labels` (Map of String) Map of labels to attach to the node pool, as customizable key/value pairs. Optional and only used at creation; changing it after the node pool exists forces a new node pool.
 - `max_pods_per_node` (Number) Maximum number of pods per node.
 - `max_replicas` (Number) Maximum number of replicas for autoscaling.
 - `min_replicas` (Number) Minimum number of replicas for autoscaling.
@@ -51,7 +59,6 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
 
 - `created_at` (String) Date of creation of the Kubernetes Node.
 - `id` (String) Node pool's UUID.
-- `labels` (Map of String) Map of labels for the node pool.
 - `security_groups` (Set of String) List of security groups for the node pool.
 - `updated_at` (String) Date of the last change to the Kubernetes Node.
 

--- a/examples/resources/mgc_kubernetes_nodepool/resource.tf
+++ b/examples/resources/mgc_kubernetes_nodepool/resource.tf
@@ -6,4 +6,11 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
   min_replicas = 1
   max_replicas = 5
   version      = mgc_kubernetes_cluster.cluster_with_nodepool.version
+
+  # Optional labels, set only at creation. Changing them recreates the node pool.
+  labels = {
+    environment = "staging"
+    team        = "devX"
+    tier        = "backend"
+  }
 }

--- a/examples/resources/mgc_kubernetes_nodepool/resource.tf
+++ b/examples/resources/mgc_kubernetes_nodepool/resource.tf
@@ -8,6 +8,8 @@ resource "mgc_kubernetes_nodepool" "nodepool" {
   version      = mgc_kubernetes_cluster.cluster_with_nodepool.version
 
   # Optional labels, set only at creation. Changing them recreates the node pool.
+  # To remove every label, set `labels = {}`. Deleting the block keeps the labels
+  # already in state.
   labels = {
     environment = "staging"
     team        = "devX"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MagaluCloud/terraform-provider-mgc
 go 1.26.3
 
 require (
-	github.com/MagaluCloud/mgc-sdk-go v1.16.0
+	github.com/MagaluCloud/mgc-sdk-go v1.17.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.27.0
@@ -24,7 +24,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tinylib/msgp v1.3.0 // indirect
-	golang.org/x/crypto v0.39.0 // indirect
+	golang.org/x/crypto v0.45.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 
@@ -47,9 +47,9 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	golang.org/x/net v0.41.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/text v0.26.0 // indirect
+	golang.org/x/net v0.47.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect
 	google.golang.org/grpc v1.72.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MagaluCloud/terraform-provider-mgc
 go 1.26.3
 
 require (
-	github.com/MagaluCloud/mgc-sdk-go v1.17.0
+	github.com/MagaluCloud/mgc-sdk-go v1.18.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
 	github.com/hashicorp/terraform-plugin-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/MagaluCloud/mgc-sdk-go v1.16.0 h1:sbxc7qKwctPiqp/g8WcGPZtsNGDMtdb1zbE6dVMRoR4=
-github.com/MagaluCloud/mgc-sdk-go v1.16.0/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
+github.com/MagaluCloud/mgc-sdk-go v1.17.0 h1:2MnDKAXTV9NmkLPiRIXDcoM6Zr/vYhfykAZGrns9FHs=
+github.com/MagaluCloud/mgc-sdk-go v1.17.0/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -111,10 +111,10 @@ go.opentelemetry.io/otel/sdk/metric v1.34.0 h1:5CeK9ujjbFVL5c1PhLuStg1wxA7vQv7ce
 go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6YvBTG1+YIqyFVFYec5w=
 go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC8mh/k=
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
-golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
-golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
-golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
-golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
+golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
+golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -122,10 +122,10 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
-golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
+golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a h1:51aaUVRocpvUOSQKM6Q7VuoaktNIaMCLuhZB6DKksq4=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a/go.mod h1:uRxBH1mhmO8PGhU89cMcHaXKZqO+OfakD8QQO0oYwlQ=
 google.golang.org/grpc v1.72.1 h1:HR03wO6eyZ7lknl75XlxABNVLLFc2PAb6mHlYh756mA=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/MagaluCloud/mgc-sdk-go v1.17.0 h1:2MnDKAXTV9NmkLPiRIXDcoM6Zr/vYhfykAZGrns9FHs=
-github.com/MagaluCloud/mgc-sdk-go v1.17.0/go.mod h1:81oQFb0jtcCu9K32raV6ZKONG9IAUdrCXvQ+nqSoOrQ=
+github.com/MagaluCloud/mgc-sdk-go v1.18.0 h1:jAPyCFFbFUHXR6wQQ4pMXLdtq+mqO7tfWXUYp8abXvE=
+github.com/MagaluCloud/mgc-sdk-go v1.18.0/go.mod h1:xGSeJPKh1vpU3CCrGyvlzr0rsqZrncfxc13sg9LBd4w=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/mgc/kubernetes/common.go
+++ b/mgc/kubernetes/common.go
@@ -148,6 +148,16 @@ func GetSubnetIDs(network *k8sSDK.Network) basetypes.SetValue {
 	return types.SetValueMust(types.StringType, subnets)
 }
 
+func convertLabelsToSDK(ctx context.Context, labels types.Map) map[string]string {
+	if labels.IsNull() || labels.IsUnknown() {
+		return nil
+	}
+
+	result := make(map[string]string, len(labels.Elements()))
+	labels.ElementsAs(ctx, &result, false)
+	return result
+}
+
 func CreateKubernetesSDKNetworkRequest(set types.Set) *k8sSDK.KubernetesNetworkRequest {
 	subnetIDs := utils.ConvertTypeSetToStringArray(set)
 	if subnetIDs == nil || len(*subnetIDs) < 1 {

--- a/mgc/kubernetes/common.go
+++ b/mgc/kubernetes/common.go
@@ -108,7 +108,10 @@ func ConvertToNodePoolToTFModel(np *k8sSDK.NodePool, region string) NodePool {
 		labelsMap, _ := types.MapValueFrom(context.Background(), types.StringType, np.Labels)
 		nodePool.Labels = labelsMap
 	} else {
-		nodePool.Labels = types.MapNull(types.StringType)
+		// The API omits labels entirely when there are none, so an empty map
+		// never round-trips. Projecting it as empty rather than null keeps the
+		// state consistent with a `labels = {}` configuration.
+		nodePool.Labels = types.MapValueMust(types.StringType, map[string]attr.Value{})
 	}
 
 	if np.SecurityGroups != nil {

--- a/mgc/kubernetes/common_test.go
+++ b/mgc/kubernetes/common_test.go
@@ -77,7 +77,7 @@ func TestConvertToNodePoolToTFModel(t *testing.T) {
 				MinReplicas:    types.Int64Value(2),
 				CreatedAt:      types.StringPointerValue(nowStr),
 				UpdatedAt:      types.StringPointerValue(nowStr),
-				Labels:         types.MapNull(types.StringType),
+				Labels:         types.MapValueMust(types.StringType, map[string]attr.Value{}),
 				SecurityGroups: types.SetNull(types.StringType),
 				Taints: &[]Taint{
 					{Key: types.StringValue("app"), Value: types.StringValue("blue"), Effect: types.StringValue("NoSchedule")},
@@ -119,7 +119,7 @@ func TestConvertToNodePoolToTFModel(t *testing.T) {
 				MinReplicas:       types.Int64Value(1),
 				CreatedAt:         types.StringPointerValue(nowStr),
 				UpdatedAt:         types.StringNull(),
-				Labels:            types.MapNull(types.StringType),
+				Labels:            types.MapValueMust(types.StringType, map[string]attr.Value{}),
 				SecurityGroups:    types.SetNull(types.StringType),
 				Taints:            nil,
 				MaxPodsPerNode:    types.Int64Null(),
@@ -143,7 +143,7 @@ func TestConvertToNodePoolToTFModel(t *testing.T) {
 				Flavor:            types.StringNull(),
 				CreatedAt:         types.StringNull(),
 				UpdatedAt:         types.StringNull(),
-				Labels:            types.MapNull(types.StringType),
+				Labels:            types.MapValueMust(types.StringType, map[string]attr.Value{}),
 				SecurityGroups:    types.SetNull(types.StringType),
 				MaxReplicas:       types.Int64Null(),
 				MinReplicas:       types.Int64Null(),
@@ -274,7 +274,7 @@ func TestConvertToNodePoolToTFModelNewFields(t *testing.T) {
 				MinReplicas:       types.Int64Null(),
 				CreatedAt:         types.StringNull(),
 				UpdatedAt:         types.StringNull(),
-				Labels:            types.MapNull(types.StringType),
+				Labels:            types.MapValueMust(types.StringType, map[string]attr.Value{}),
 				SecurityGroups:    types.SetNull(types.StringType),
 				MaxPodsPerNode:    types.Int64Null(),
 				Taints:            nil,
@@ -353,20 +353,14 @@ func TestConvertToNodePoolToTFModelNewFields(t *testing.T) {
 			assert.Equal(t, tc.expected.AvailabilityZones, result.AvailabilityZones)
 
 			// Validate labels conversion
+			assert.False(t, result.Labels.IsNull())
+			var resultLabels map[string]string
+			diags := result.Labels.ElementsAs(context.Background(), &resultLabels, false)
+			assert.False(t, diags.HasError())
 			if len(tc.input.Labels) > 0 {
-				assert.False(t, result.Labels.IsNull())
-				var resultLabels map[string]string
-				diags := result.Labels.ElementsAs(context.Background(), &resultLabels, false)
-				assert.False(t, diags.HasError())
 				assert.Equal(t, tc.input.Labels, resultLabels)
 			} else {
-				// Labels should be null or empty map
-				if !result.Labels.IsNull() {
-					var resultLabels map[string]string
-					diags := result.Labels.ElementsAs(context.Background(), &resultLabels, false)
-					assert.False(t, diags.HasError())
-					assert.Empty(t, resultLabels)
-				}
+				assert.Empty(t, resultLabels)
 			}
 
 			// Validate security groups conversion
@@ -440,12 +434,12 @@ func TestConvertToNodePoolToTFModelEdgeCases(t *testing.T) {
 		assert.Contains(t, resultSGs, "sg-3")
 	})
 
-	t.Run("should_handle_nil_maps_correctly", func(t *testing.T) {
+	t.Run("labels absent from the API become an empty map, never null", func(t *testing.T) {
 		input := &k8sSDK.NodePool{
 			ID:       "np-nil-map",
 			Name:     "nil-map-pool",
 			Replicas: 1,
-			Labels:   nil, // nil map should be handled gracefully
+			Labels:   nil, // the API omits labels entirely when there are none
 			InstanceTemplate: k8sSDK.InstanceTemplate{
 				Flavor: k8sSDK.Flavor{Name: "test-flavor"},
 			},
@@ -453,13 +447,14 @@ func TestConvertToNodePoolToTFModelEdgeCases(t *testing.T) {
 
 		result := ConvertToNodePoolToTFModel(input, "us-east-1")
 
-		// For nil maps, len() returns 0, so Labels should be null or empty
-		if !result.Labels.IsNull() {
-			var resultLabels map[string]string
-			diags := result.Labels.ElementsAs(context.Background(), &resultLabels, false)
-			assert.False(t, diags.HasError())
-			assert.Empty(t, resultLabels)
-		}
+		// A `labels = {}` configuration must round-trip: projecting the absent
+		// labels as null would make the applied state differ from the config.
+		assert.False(t, result.Labels.IsNull())
+
+		var resultLabels map[string]string
+		diags := result.Labels.ElementsAs(context.Background(), &resultLabels, false)
+		assert.False(t, diags.HasError())
+		assert.Empty(t, resultLabels)
 	})
 
 }

--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -117,10 +117,13 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 			},
 
 			"labels": schema.MapAttribute{
-				Description: "Map of labels for the node pool.",
+				Description: "Map of labels to attach to the node pool, as customizable key/value pairs. " +
+					"Optional and only used at creation; changing it after the node pool exists forces a new node pool.",
+				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,
 				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.RequiresReplace(),
 					mapplanmodifier.UseStateForUnknown(),
 				},
 			},
@@ -270,6 +273,7 @@ func (r *NewNodePoolResource) Create(ctx context.Context, req resource.CreateReq
 		Taints:         convertTaintsNP(data.Taints),
 		MaxPodsPerNode: utils.ConvertInt64PointerToIntPointer(data.MaxPodsPerNode.ValueInt64Pointer()),
 		Network:        CreateKubernetesSDKNetworkRequest(data.SubnetIDs),
+		Labels:         convertLabelsToSDK(ctx, data.Labels),
 	}
 
 	if !data.MaxReplicas.IsNull() || !data.MinReplicas.IsNull() {

--- a/mgc/kubernetes/resource_nodepool.go
+++ b/mgc/kubernetes/resource_nodepool.go
@@ -118,7 +118,10 @@ func (r *NewNodePoolResource) Schema(_ context.Context, req resource.SchemaReque
 
 			"labels": schema.MapAttribute{
 				Description: "Map of labels to attach to the node pool, as customizable key/value pairs. " +
-					"Optional and only used at creation; changing it after the node pool exists forces a new node pool.",
+					"Optional and only used at creation; changing it after the node pool exists forces a new node pool. " +
+					"To remove every label, set `labels = {}` explicitly: removing the attribute from the " +
+					"configuration keeps the labels already recorded in state, because the value is computed " +
+					"whenever it is not configured.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,

--- a/mgc/kubernetes/resource_nodepool_test.go
+++ b/mgc/kubernetes/resource_nodepool_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -214,6 +215,42 @@ func TestConvertTaintsNP(t *testing.T) {
 	})
 }
 
+func TestConvertLabelsToSDK(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns nil for a null map so labels are omitted from the request", func(t *testing.T) {
+		result := convertLabelsToSDK(ctx, types.MapNull(types.StringType))
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil for an unknown map", func(t *testing.T) {
+		result := convertLabelsToSDK(ctx, types.MapUnknown(types.StringType))
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns an empty map when the customer sets no pairs", func(t *testing.T) {
+		empty, diags := types.MapValueFrom(ctx, types.StringType, map[string]string{})
+		assert.False(t, diags.HasError())
+
+		result := convertLabelsToSDK(ctx, empty)
+		assert.NotNil(t, result)
+		assert.Empty(t, result)
+	})
+
+	t.Run("converts the customer-chosen key/value pairs", func(t *testing.T) {
+		labels := map[string]string{
+			"environment": "staging",
+			"team":        "devX",
+			"tier":        "backend",
+		}
+		tfMap, diags := types.MapValueFrom(ctx, types.StringType, labels)
+		assert.False(t, diags.HasError())
+
+		result := convertLabelsToSDK(ctx, tfMap)
+		assert.Equal(t, labels, result)
+	})
+}
+
 func TestGetSubnetIDs(t *testing.T) {
 	t.Run("a network's subnets are exposed as the set of their IDs", func(t *testing.T) {
 		network := &k8sSDK.Network{
@@ -403,6 +440,41 @@ func TestNodePoolSchemaMaxPodsPerNodePlanModifiers(t *testing.T) {
 				hasRequiresReplace = true
 			}
 			if reflect.TypeOf(modifier) == reflect.TypeOf(int64planmodifier.UseStateForUnknown()) {
+				hasUseStateForUnknown = true
+			}
+		}
+
+		assert.True(t, hasRequiresReplace)
+		assert.True(t, hasUseStateForUnknown)
+	})
+}
+
+func TestNodePoolSchemaLabelsPlanModifiers(t *testing.T) {
+	r := &NewNodePoolResource{}
+	resp := &resource.SchemaResponse{}
+
+	r.Schema(context.Background(), resource.SchemaRequest{}, resp)
+
+	attrRaw, ok := resp.Schema.Attributes["labels"]
+	assert.True(t, ok)
+
+	attr, ok := attrRaw.(schema.MapAttribute)
+	assert.True(t, ok)
+
+	t.Run("labels is optional and computed so customers can set it at creation", func(t *testing.T) {
+		assert.True(t, attr.Optional)
+		assert.True(t, attr.Computed)
+	})
+
+	t.Run("changing labels forces replacement and unknown falls back to state", func(t *testing.T) {
+		hasRequiresReplace := false
+		hasUseStateForUnknown := false
+
+		for _, modifier := range attr.PlanModifiers {
+			if reflect.TypeOf(modifier) == reflect.TypeOf(mapplanmodifier.RequiresReplace()) {
+				hasRequiresReplace = true
+			}
+			if reflect.TypeOf(modifier) == reflect.TypeOf(mapplanmodifier.UseStateForUnknown()) {
 				hasUseStateForUnknown = true
 			}
 		}

--- a/mgc/objects/datasource_object.go
+++ b/mgc/objects/datasource_object.go
@@ -113,7 +113,7 @@ func (d *ObjectStorageObjectDataSource) Read(ctx context.Context, req datasource
 	bucketName := data.Bucket.ValueString()
 	objectKey := data.Key.ValueString()
 
-	objMeta, err := d.objects.Metadata(ctx, bucketName, objectKey)
+	objMeta, err := d.objects.Metadata(ctx, bucketName, objectKey, nil)
 	if err != nil {
 		errStr := err.Error()
 		if strings.Contains(errStr, "NoSuchKey") || strings.Contains(errStr, "not found") || strings.Contains(errStr, "does not exist") {

--- a/mgc/objects/resource_objects.go
+++ b/mgc/objects/resource_objects.go
@@ -197,7 +197,7 @@ func (r *objectStorageObjects) Create(ctx context.Context, req resource.CreateRe
 		}
 	}
 
-	objMeta, err := r.objects.Metadata(ctx, plan.Bucket.ValueString(), plan.Key.ValueString())
+	objMeta, err := r.objects.Metadata(ctx, plan.Bucket.ValueString(), plan.Key.ValueString(), nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading object metadata",
 			fmt.Sprintf("Could not read metadata for object %s: %s", plan.Key.ValueString(), err.Error()))
@@ -222,7 +222,7 @@ func (r *objectStorageObjects) Read(ctx context.Context, req resource.ReadReques
 	bucketName := state.Bucket.ValueString()
 	objectKey := state.Key.ValueString()
 
-	objMeta, err := r.objects.Metadata(ctx, bucketName, objectKey)
+	objMeta, err := r.objects.Metadata(ctx, bucketName, objectKey, nil)
 	if err != nil {
 		errStr := err.Error()
 		if strings.Contains(errStr, "NoSuchKey") || strings.Contains(errStr, "not found") || strings.Contains(errStr, "does not exist") {
@@ -269,7 +269,7 @@ func (r *objectStorageObjects) contentChanged(ctx context.Context, plan, state *
 		return false, err
 	}
 
-	meta, err := r.objects.Metadata(ctx, plan.Bucket.ValueString(), plan.Key.ValueString())
+	meta, err := r.objects.Metadata(ctx, plan.Bucket.ValueString(), plan.Key.ValueString(), nil)
 	if err != nil {
 		return true, nil
 	}
@@ -342,7 +342,7 @@ func (r *objectStorageObjects) Update(ctx context.Context, req resource.UpdateRe
 		}
 	}
 
-	objMeta, err := r.objects.Metadata(ctx, plan.Bucket.ValueString(), plan.Key.ValueString())
+	objMeta, err := r.objects.Metadata(ctx, plan.Bucket.ValueString(), plan.Key.ValueString(), nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading object metadata",
 			fmt.Sprintf("Could not read metadata for object %s: %s", plan.Key.ValueString(), err.Error()))


### PR DESCRIPTION
## What does this PR do?
Torna o atributo `labels` do mgc_kubernetes_nodepool definível pelo
usuário, permitindo marcar node pools com pares chave/valor customizados


## How Has This Been Tested?
Testes executados localmente

```
resource "mgc_kubernetes_nodepool" "nodepool" {
  name        = "test-4mai1955"
  cluster_id  = mgc_kubernetes_cluster.cluster.id
  flavor_name = "BV2-2-40"
  replicas    = 2
  //subnet_ids = [mgc_network_vpcs_subnets.vpc_subnet_ipv4_a.id, mgc_network_vpcs_subnets.vpc_subnet_ipv4_b.id]
  //version = mgc_kubernetes_cluster.cluster.version
  min_replicas = 1
  max_replicas = 3
  labels = {
    environment = "staging"
    team        = "DevX"
    tier        = "backend"
  }
}

data "mgc_kubernetes_nodepool" "nodepool" {
  id         = mgc_kubernetes_nodepool.nodepool.id
  cluster_id = mgc_kubernetes_cluster.cluster.id
}

output "nodepool" {
  value = data.mgc_kubernetes_nodepool.nodepool.labels
}
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
